### PR TITLE
remove bind arg to CMD, the default is already to bind everywhere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ WORKDIR /data
 
 USER redis
 EXPOSE 6379
-CMD [ "redis-server", "--bind", "0.0.0.0" ]
+CMD [ "redis-server" ]


### PR DESCRIPTION
From the [redis.conf](http://download.redis.io/redis-stable/redis.conf):

```
# By default Redis listens for connections from all the network interfaces
# available on the server. It is possible to listen to just one or multiple
# interfaces using the "bind" configuration directive, followed by one or
# more IP addresses.
```

ping @tianon  
