### PR TITLE
Update to 2.8.21 and 3.0.2

### DIFF
--- a/2.8/Dockerfile
+++ b/2.8/Dockerfile
@@ -15,9 +15,9 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-ENV REDIS_VERSION 2.8.20
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-2.8.20.tar.gz
-ENV REDIS_DOWNLOAD_SHA1 45f134113fb3d75b8c37f7968e46565a70800091
+ENV REDIS_VERSION 2.8.21
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-2.8.21.tar.gz
+ENV REDIS_DOWNLOAD_SHA1 52f619d3d301fc7ae498a1d4cb4d44ecebc5b0f9
 
 # for redis-sentinel see: http://redis.io/topics/sentinel
 RUN buildDeps='gcc libc6-dev make' \

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -15,9 +15,9 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-ENV REDIS_VERSION 3.0.1
-ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-3.0.1.tar.gz
-ENV REDIS_DOWNLOAD_SHA1 fe1d06599042bfe6a0e738542f302ce9533dde88
+ENV REDIS_VERSION 3.0.2
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-3.0.2.tar.gz
+ENV REDIS_DOWNLOAD_SHA1 a38755fe9a669896f7c5d8cd3ebbf76d59712002
 
 # for redis-sentinel see: http://redis.io/topics/sentinel
 RUN buildDeps='gcc libc6-dev make'; \


### PR DESCRIPTION
see: https://groups.google.com/forum/#!msg/redis-db/4Y6OqK8gEyk/Dg-5cejl-eUJ

> A few minutes ago I released Redis 3.0.2 and 2.8.1. The main reason
for this release is to address a security bug found by Ben Murphy,
documented in his blog post here:

> http://benmmurphy.github.io/blog/2015/06/04/redis-eval-lua-sandbox-escape/

> It is critical but not dramatic: it needs the attacker to have direct
access to the instance, so Redis access mediated by applications is
not at risk. There are a lot of details about vulnerable deployments
in the original blog post. 