### PR TITLE
Switch redis:alpine over to su-exec

### DIFF
--- a/2.8/32bit/Dockerfile
+++ b/2.8/32bit/Dockerfile
@@ -45,8 +45,9 @@ RUN mkdir /data && chown redis:redis /data
 VOLUME /data
 WORKDIR /data
 
-COPY docker-entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD [ "redis-server" ]

--- a/2.8/32bit/docker-entrypoint.sh
+++ b/2.8/32bit/docker-entrypoint.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
 	chown -R redis .
-	exec gosu redis "$BASH_SOURCE" "$@"
+	exec gosu redis "$0" "$@"
 fi
 
 exec "$@"

--- a/2.8/Dockerfile
+++ b/2.8/Dockerfile
@@ -43,8 +43,9 @@ RUN mkdir /data && chown redis:redis /data
 VOLUME /data
 WORKDIR /data
 
-COPY docker-entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD [ "redis-server" ]

--- a/2.8/docker-entrypoint.sh
+++ b/2.8/docker-entrypoint.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
 	chown -R redis .
-	exec gosu redis "$BASH_SOURCE" "$@"
+	exec gosu redis "$0" "$@"
 fi
 
 exec "$@"

--- a/3.0/32bit/Dockerfile
+++ b/3.0/32bit/Dockerfile
@@ -45,8 +45,9 @@ RUN mkdir /data && chown redis:redis /data
 VOLUME /data
 WORKDIR /data
 
-COPY docker-entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD [ "redis-server" ]

--- a/3.0/32bit/docker-entrypoint.sh
+++ b/3.0/32bit/docker-entrypoint.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
 	chown -R redis .
-	exec gosu redis "$BASH_SOURCE" "$@"
+	exec gosu redis "$0" "$@"
 fi
 
 exec "$@"

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -43,8 +43,9 @@ RUN mkdir /data && chown redis:redis /data
 VOLUME /data
 WORKDIR /data
 
-COPY docker-entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD [ "redis-server" ]

--- a/3.0/alpine/Dockerfile
+++ b/3.0/alpine/Dockerfile
@@ -17,11 +17,11 @@ RUN set -x \
 		linux-headers \
 		make \
 		musl-dev \
+		tar \
 	&& wget -O redis.tar.gz "$REDIS_DOWNLOAD_URL" \
 	&& echo "$REDIS_DOWNLOAD_SHA1 *redis.tar.gz" | sha1sum -c - \
-	&& mkdir -p /usr/src \
-	&& tar -xzf redis.tar.gz -C /usr/src \
-	&& mv "/usr/src/redis-$REDIS_VERSION" /usr/src/redis \
+	&& mkdir -p /usr/src/redis \
+	&& tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1 \
 	&& rm redis.tar.gz \
 	&& make -C /usr/src/redis \
 	&& make -C /usr/src/redis install \
@@ -32,8 +32,9 @@ RUN mkdir /data && chown redis:redis /data
 VOLUME /data
 WORKDIR /data
 
-COPY docker-entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD [ "redis-server" ]

--- a/3.0/alpine/Dockerfile
+++ b/3.0/alpine/Dockerfile
@@ -3,22 +3,8 @@ FROM alpine:3.3
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN addgroup -S redis && adduser -S -G redis redis
 
-# grab gosu for easy step-down from root
-ENV GOSU_VERSION 1.7
-RUN set -x \
-	&& apk add --no-cache --virtual .gosu-deps \
-		dpkg \
-		gnupg \
-		openssl \
-	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& gosu nobody true \
-	&& apk del .gosu-deps
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
 
 ENV REDIS_VERSION 3.0.7
 ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-3.0.7.tar.gz

--- a/3.0/alpine/docker-entrypoint.sh
+++ b/3.0/alpine/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
 	chown -R redis .
-	exec gosu redis "$0" "$@"
+	exec su-exec redis "$0" "$@"
 fi
 
 exec "$@"

--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
 	chown -R redis .
-	exec gosu redis "$BASH_SOURCE" "$@"
+	exec gosu redis "$0" "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
After https://github.com/ncopa/su-exec/commit/f85e5bde1afef399021fbc2a99c837cf851ceafa (`su-exec` 0.2+), `su-exec` now has parity with `gosu` (as verified by `gosu`'s new test suite) such that it's acceptable to use as a `gosu` replacement in our Alpine-based variant for the size consideration.