### PR TITLE
Move "--protected-mode no" into the entrypoint instead

### DIFF
--- a/2.8/32bit/docker-entrypoint.sh
+++ b/2.8/32bit/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- redis-server "$@"
+fi
+
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
 	chown -R redis .

--- a/2.8/docker-entrypoint.sh
+++ b/2.8/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- redis-server "$@"
+fi
+
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
 	chown -R redis .

--- a/3.0/32bit/docker-entrypoint.sh
+++ b/3.0/32bit/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- redis-server "$@"
+fi
+
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
 	chown -R redis .

--- a/3.0/alpine/docker-entrypoint.sh
+++ b/3.0/alpine/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- redis-server "$@"
+fi
+
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
 	chown -R redis .

--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- redis-server "$@"
+fi
+
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
 	chown -R redis .

--- a/3.2/32bit/Dockerfile
+++ b/3.2/32bit/Dockerfile
@@ -49,9 +49,4 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
-
-# Disable Redis protected mode [1] as it is unnecessary in context
-# of Docker. Ports are not automatically exposed when running inside
-# Docker, but rather explicitely by specifying -p / -P.
-# [1] https://github.com/antirez/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-CMD [ "redis-server", "--protected-mode", "no" ]
+CMD [ "redis-server" ]

--- a/3.2/32bit/docker-entrypoint.sh
+++ b/3.2/32bit/docker-entrypoint.sh
@@ -1,10 +1,25 @@
 #!/bin/sh
 set -e
 
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- redis-server "$@"
+fi
+
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
 	chown -R redis .
 	exec gosu redis "$0" "$@"
+fi
+
+if [ "$1" = 'redis-server' ]; then
+	# Disable Redis protected mode [1] as it is unnecessary in context
+	# of Docker. Ports are not automatically exposed when running inside
+	# Docker, but rather explicitely by specifying -p / -P.
+	# [1] https://github.com/antirez/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	shift # "redis-server"
+	set -- redis-server --protected-mode no "$@"
+	# if this is supplied again, the "latest" wins, so "--protected-mode no --protected-mode yes" will result in an enabled status
 fi
 
 exec "$@"

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -47,9 +47,4 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
-
-# Disable Redis protected mode [1] as it is unnecessary in context
-# of Docker. Ports are not automatically exposed when running inside
-# Docker, but rather explicitely by specifying -p / -P.
-# [1] https://github.com/antirez/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-CMD [ "redis-server", "--protected-mode", "no" ]
+CMD [ "redis-server" ]

--- a/3.2/alpine/Dockerfile
+++ b/3.2/alpine/Dockerfile
@@ -36,9 +36,4 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
-
-# Disable Redis protected mode [1] as it is unnecessary in context
-# of Docker. Ports are not automatically exposed when running inside
-# Docker, but rather explicitely by specifying -p / -P.
-# [1] https://github.com/antirez/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-CMD [ "redis-server", "--protected-mode", "no" ]
+CMD [ "redis-server" ]

--- a/3.2/alpine/docker-entrypoint.sh
+++ b/3.2/alpine/docker-entrypoint.sh
@@ -1,10 +1,25 @@
 #!/bin/sh
 set -e
 
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- redis-server "$@"
+fi
+
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
 	chown -R redis .
 	exec su-exec redis "$0" "$@"
+fi
+
+if [ "$1" = 'redis-server' ]; then
+	# Disable Redis protected mode [1] as it is unnecessary in context
+	# of Docker. Ports are not automatically exposed when running inside
+	# Docker, but rather explicitely by specifying -p / -P.
+	# [1] https://github.com/antirez/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	shift # "redis-server"
+	set -- redis-server --protected-mode no "$@"
+	# if this is supplied again, the "latest" wins, so "--protected-mode no --protected-mode yes" will result in an enabled status
 fi
 
 exec "$@"

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -1,10 +1,25 @@
 #!/bin/sh
 set -e
 
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- redis-server "$@"
+fi
+
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
 	chown -R redis .
 	exec gosu redis "$0" "$@"
+fi
+
+if [ "$1" = 'redis-server' ]; then
+	# Disable Redis protected mode [1] as it is unnecessary in context
+	# of Docker. Ports are not automatically exposed when running inside
+	# Docker, but rather explicitely by specifying -p / -P.
+	# [1] https://github.com/antirez/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	shift # "redis-server"
+	set -- redis-server --protected-mode no "$@"
+	# if this is supplied again, the "latest" wins, so "--protected-mode no --protected-mode yes" will result in an enabled status
 fi
 
 exec "$@"


### PR DESCRIPTION
Since doubling up on this option will have the "latest" version win, we're safe (in the sense of an image user being able to still override it) to apply this to all invocations of the server.

This change also includes the glue necessary to allow for `docker run redis --flag`, which frustrated me while I was testing this change.

Fixes #58