### PR TITLE
make docker-entrypoint.sh executable

### DIFF
--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -71,6 +71,7 @@ VOLUME /data
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379


### PR DESCRIPTION
fix  issue
"starting container process caused "exec: \"docker-entrypoint.sh\": executable file not found i
n $PATH".
