### PR TITLE
adds missing libraries from scanelf search

### DIFF
--- a/3.2/alpine/Dockerfile
+++ b/3.2/alpine/Dockerfile
@@ -42,12 +42,16 @@ RUN set -ex; \
 	\
 	rm -r /usr/src/redis; \
 	\
-	apk del .build-deps; \
-	\
-	apk add -vv --no-cache $(scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
 			| tr ',' '\n' \
 			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }')
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --virtual .redis-rundeps $runDeps; \
+	apk del .build-deps; \
+	\
+	redis-server --version
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/3.2/alpine/Dockerfile
+++ b/3.2/alpine/Dockerfile
@@ -42,7 +42,12 @@ RUN set -ex; \
 	\
 	rm -r /usr/src/redis; \
 	\
-	apk del .build-deps
+	apk del .build-deps; \
+	\
+	apk add -vv --no-cache $(scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }')
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -42,12 +42,16 @@ RUN set -ex; \
 	\
 	rm -r /usr/src/redis; \
 	\
-	apk del .build-deps; \
-	\
-	apk add -vv --no-cache $(scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
 			| tr ',' '\n' \
 			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }')
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --virtual .redis-rundeps $runDeps; \
+	apk del .build-deps; \
+	\
+	redis-server --version
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -42,7 +42,12 @@ RUN set -ex; \
 	\
 	rm -r /usr/src/redis; \
 	\
-	apk del .build-deps
+	apk del .build-deps; \
+	\
+	apk add -vv --no-cache $(scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }')
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data


### PR DESCRIPTION
* could be the case that dynamic libraries are missing after deleting the build-deps, so they need to be installed afterwards again

NOTE

* doesn't matter if scanelf is executed before or after removing the build-deps

* see #124 for details (link to ruby solution)