### PR TITLE
Implement docker healthchecks

### DIFF
--- a/3.2/32bit/Dockerfile
+++ b/3.2/32bit/Dockerfile
@@ -84,5 +84,8 @@ WORKDIR /data
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+	CMD /usr/local/bin/redis-cli PING || exit 1
+
 EXPOSE 6379
 CMD ["redis-server"]

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -79,5 +79,8 @@ WORKDIR /data
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+	CMD /usr/local/bin/redis-cli PING || exit 1
+
 EXPOSE 6379
 CMD ["redis-server"]

--- a/3.2/alpine/Dockerfile
+++ b/3.2/alpine/Dockerfile
@@ -61,5 +61,8 @@ WORKDIR /data
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+	CMD /usr/local/bin/redis-cli PING || exit 1
+
 EXPOSE 6379
 CMD ["redis-server"]

--- a/4.0/32bit/Dockerfile
+++ b/4.0/32bit/Dockerfile
@@ -84,5 +84,8 @@ WORKDIR /data
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+	CMD /usr/local/bin/redis-cli PING || exit 1
+
 EXPOSE 6379
 CMD ["redis-server"]

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -79,5 +79,8 @@ WORKDIR /data
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+	CMD /usr/local/bin/redis-cli PING || exit 1
+
 EXPOSE 6379
 CMD ["redis-server"]

--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -61,5 +61,8 @@ WORKDIR /data
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+	CMD /usr/local/bin/redis-cli PING || exit 1
+
 EXPOSE 6379
 CMD ["redis-server"]

--- a/5.0-rc/32bit/Dockerfile
+++ b/5.0-rc/32bit/Dockerfile
@@ -85,5 +85,8 @@ WORKDIR /data
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+	CMD /usr/local/bin/redis-cli PING || exit 1
+
 EXPOSE 6379
 CMD ["redis-server"]

--- a/5.0-rc/Dockerfile
+++ b/5.0-rc/Dockerfile
@@ -80,5 +80,8 @@ WORKDIR /data
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+	CMD /usr/local/bin/redis-cli PING || exit 1
+
 EXPOSE 6379
 CMD ["redis-server"]

--- a/5.0-rc/alpine/Dockerfile
+++ b/5.0-rc/alpine/Dockerfile
@@ -63,5 +63,8 @@ WORKDIR /data
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+	CMD /usr/local/bin/redis-cli PING || exit 1
+
 EXPOSE 6379
 CMD ["redis-server"]


### PR DESCRIPTION
Implement a healthcheck for all docker images. The healthcheck will execute a PING command to the redis server every 30 seconds. When this command fails by either a timeout of 5 seconds or unexpected output, the healthcheck will fail and trigger an event which a user can capture.

One thing I'm not sure about is the numbers I used, specifically for the interval(30s) and the timeout (5s). These can be changed if necessary.

Output in `docker ps`(see the status column):
```
# First 30 seconds when a container was started
CONTAINER ID        IMAGE                              COMMAND                  CREATED             STATUS                            PORTS                                              NAMES
455a1e6bf0c1        test/redis:latest                  "docker-entrypoint.s…"   2 minutes ago       Up 6 seconds (health: starting)   6379/tcp, 0.0.0.0:6379->63799/tcp                  test-redis

# After 30 seconds when the first healthcheck was executed
CONTAINER ID        IMAGE                              COMMAND                  CREATED             STATUS                    PORTS                                              NAMES
455a1e6bf0c1        test/redis:latest                  "docker-entrypoint.s…"   2 minutes ago       Up 42 seconds (healthy)   6379/tcp, 0.0.0.0:6379->63799/tcp                  test-redis
```

Full reference here: https://docs.docker.com/engine/reference/builder/#healthcheck
Fixes #91 