### PR TITLE
rm 5.0-rc/alpine/Dockerfile wget install

### DIFF
--- a/5.0-rc/alpine/Dockerfile
+++ b/5.0-rc/alpine/Dockerfile
@@ -21,7 +21,6 @@ RUN set -ex; \
 		linux-headers \
 		make \
 		musl-dev \
-		wget \
 	; \
 	\
 	wget -O redis.tar.gz "$REDIS_DOWNLOAD_URL"; \

--- a/5.0-rc/alpine/Dockerfile
+++ b/5.0-rc/alpine/Dockerfile
@@ -14,7 +14,6 @@ ENV REDIS_DOWNLOAD_SHA 4bb2eeef3695d66d8b64767825acfeeb157d64536233eac7eae71b236
 RUN set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
-		ca-certificates \
 		coreutils \
 		gcc \
 		jemalloc-dev \


### PR DESCRIPTION
Base on Alpine 3.8 we can use the BusyBox v1.28.4's default `wget`.

And when we delete this line, the image can decreases 209B `/root/.wget-hsts`.

```bash
(Tao) ➜  workspace sudo container-diff diff daemon://redis:5.0-rc-alpine daemon://local/redis:5.0-rc-alpine-no-install-wget  --typ
e=file

-----File-----

These entries have been added to redis:5.0-rc-alpine: None

These entries have been deleted from redis:5.0-rc-alpine:
FILE                    SIZE
/root/.wget-hsts        209B

```