### PR TITLE
Only chown things in the entrypoint that are not already owned by redis

### DIFF
--- a/3.2/32bit/docker-entrypoint.sh
+++ b/3.2/32bit/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
-	chown -R redis .
+	find . \! -user redis -exec chown redis '{}' +
 	exec gosu redis "$0" "$@"
 fi
 

--- a/3.2/alpine/docker-entrypoint.sh
+++ b/3.2/alpine/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
-	chown -R redis .
+	find . \! -user redis -exec chown redis '{}' +
 	exec su-exec redis "$0" "$@"
 fi
 

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
-	chown -R redis .
+	find . \! -user redis -exec chown redis '{}' +
 	exec gosu redis "$0" "$@"
 fi
 

--- a/4.0/32bit/docker-entrypoint.sh
+++ b/4.0/32bit/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
-	chown -R redis .
+	find . \! -user redis -exec chown redis '{}' +
 	exec gosu redis "$0" "$@"
 fi
 

--- a/4.0/alpine/docker-entrypoint.sh
+++ b/4.0/alpine/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
-	chown -R redis .
+	find . \! -user redis -exec chown redis '{}' +
 	exec su-exec redis "$0" "$@"
 fi
 

--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
-	chown -R redis .
+	find . \! -user redis -exec chown redis '{}' +
 	exec gosu redis "$0" "$@"
 fi
 

--- a/5.0-rc/32bit/docker-entrypoint.sh
+++ b/5.0-rc/32bit/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
-	chown -R redis .
+	find . \! -user redis -exec chown redis '{}' +
 	exec gosu redis "$0" "$@"
 fi
 

--- a/5.0-rc/alpine/docker-entrypoint.sh
+++ b/5.0-rc/alpine/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
-	chown -R redis .
+	find . \! -user redis -exec chown redis '{}' +
 	exec su-exec redis "$0" "$@"
 fi
 

--- a/5.0-rc/docker-entrypoint.sh
+++ b/5.0-rc/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'redis-server' -a "$(id -u)" = '0' ]; then
-	chown -R redis .
+	find . \! -user redis -exec chown redis '{}' +
 	exec gosu redis "$0" "$@"
 fi
 


### PR DESCRIPTION
Same as https://github.com/docker-library/rabbitmq/pull/281, https://github.com/docker-library/mariadb/pull/203, https://github.com/docker-library/percona/pull/69, https://github.com/docker-library/redmine/pull/128, https://github.com/docker-library/mongo/pull/305, https://github.com/docker-library/cassandra/pull/158