### PR TITLE
EOL 3.2 and remove Travis CI configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ env:
   - VERSION=4.0 VARIANT=
   - VERSION=4.0 VARIANT=32bit
   - VERSION=4.0 VARIANT=alpine
-  - VERSION=3.2 VARIANT=
-  - VERSION=3.2 VARIANT=32bit
-  - VERSION=3.2 VARIANT=alpine
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images


### PR DESCRIPTION
Because of the commit  https://github.com/docker-library/redis/commit/dc6dc737baa434528ce31948b22b4c6ccc78793a , we shoul remove the Travis CI env configs for 3.2. 

The faild job is https://travis-ci.org/docker-library/redis/jobs/442889666 . 


Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>