### PR TITLE
Deduplicate and strip binaries

### DIFF
--- a/4.0/32bit/Dockerfile
+++ b/4.0/32bit/Dockerfile
@@ -73,7 +73,7 @@ RUN set -ex; \
 	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_AOF_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_AOF_NAME),g' /usr/src/redis/src/Makefile; \
 	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_RDB_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_RDB_NAME),g' /usr/src/redis/src/Makefile; \
 	\
-	make -C /usr/src/redis -j "$(nproc)" DEBUG="-s" 32bit install; \
+	make -C /usr/src/redis -j "$(nproc)" 32bit install; \
 	\
 	rm -r /usr/src/redis; \
 	\

--- a/4.0/32bit/Dockerfile
+++ b/4.0/32bit/Dockerfile
@@ -70,8 +70,10 @@ RUN set -ex; \
 # see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
 # (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
 	\
-	make -C /usr/src/redis -j "$(nproc)" 32bit; \
-	make -C /usr/src/redis install; \
+	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_AOF_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_AOF_NAME),g' /usr/src/redis/src/Makefile; \
+	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_RDB_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_RDB_NAME),g' /usr/src/redis/src/Makefile; \
+	\
+	make -C /usr/src/redis -j "$(nproc)" DEBUG="-s" 32bit install; \
 	\
 	rm -r /usr/src/redis; \
 	\

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -65,8 +65,10 @@ RUN set -ex; \
 # see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
 # (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
 	\
-	make -C /usr/src/redis -j "$(nproc)"; \
-	make -C /usr/src/redis install; \
+	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_AOF_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_AOF_NAME),g' /usr/src/redis/src/Makefile; \
+	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_RDB_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_RDB_NAME),g' /usr/src/redis/src/Makefile; \
+	\
+	make -C /usr/src/redis -j "$(nproc)" DEBUG="-s" install; \
 	\
 	rm -r /usr/src/redis; \
 	\

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -68,7 +68,7 @@ RUN set -ex; \
 	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_AOF_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_AOF_NAME),g' /usr/src/redis/src/Makefile; \
 	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_RDB_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_RDB_NAME),g' /usr/src/redis/src/Makefile; \
 	\
-	make -C /usr/src/redis -j "$(nproc)" DEBUG="-s" install; \
+	make -C /usr/src/redis -j "$(nproc)" install; \
 	\
 	rm -r /usr/src/redis; \
 	\

--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -44,7 +44,7 @@ RUN set -ex; \
 	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_AOF_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_AOF_NAME),g' /usr/src/redis/src/Makefile; \
 	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_RDB_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_RDB_NAME),g' /usr/src/redis/src/Makefile; \
 	\
-	make -C /usr/src/redis -j "$(nproc)" DEBUG="-s" install; \
+	make -C /usr/src/redis -j "$(nproc)" install; \
 	\
 	rm -r /usr/src/redis; \
 	\

--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -41,8 +41,10 @@ RUN set -ex; \
 # see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
 # (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
 	\
-	make -C /usr/src/redis -j "$(nproc)"; \
-	make -C /usr/src/redis install; \
+	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_AOF_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_AOF_NAME),g' /usr/src/redis/src/Makefile; \
+	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_RDB_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_RDB_NAME),g' /usr/src/redis/src/Makefile; \
+	\
+	make -C /usr/src/redis -j "$(nproc)" DEBUG="-s" install; \
 	\
 	rm -r /usr/src/redis; \
 	\
@@ -52,8 +54,8 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --virtual .redis-rundeps $runDeps; \
-	apk del .build-deps; \
+	apk add --no-cache --virtual .redis-rundeps $runDeps; \
+	apk del --no-cache --purge .build-deps; \
 	\
 	redis-server --version
 

--- a/5.0/32bit/Dockerfile
+++ b/5.0/32bit/Dockerfile
@@ -71,8 +71,10 @@ RUN set -ex; \
 # see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
 # (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
 	\
-	make -C /usr/src/redis -j "$(nproc)" 32bit; \
-	make -C /usr/src/redis install; \
+	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_AOF_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_AOF_NAME),g' /usr/src/redis/src/Makefile; \
+	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_RDB_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_RDB_NAME),g' /usr/src/redis/src/Makefile; \
+	\
+	make -C /usr/src/redis -j "$(nproc)" DEBUG="-s" 32bit install; \
 	\
 	rm -r /usr/src/redis; \
 	\

--- a/5.0/32bit/Dockerfile
+++ b/5.0/32bit/Dockerfile
@@ -74,7 +74,7 @@ RUN set -ex; \
 	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_AOF_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_AOF_NAME),g' /usr/src/redis/src/Makefile; \
 	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_RDB_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_RDB_NAME),g' /usr/src/redis/src/Makefile; \
 	\
-	make -C /usr/src/redis -j "$(nproc)" DEBUG="-s" 32bit install; \
+	make -C /usr/src/redis -j "$(nproc)" 32bit install; \
 	\
 	rm -r /usr/src/redis; \
 	\

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex; \
 	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_AOF_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_AOF_NAME),g' /usr/src/redis/src/Makefile; \
 	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_RDB_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_RDB_NAME),g' /usr/src/redis/src/Makefile; \
 	\
-	make -C /usr/src/redis -j "$(nproc)" DEBUG="-s" install; \
+	make -C /usr/src/redis -j "$(nproc)" install; \
 	\
 	rm -r /usr/src/redis; \
 	\

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -66,8 +66,10 @@ RUN set -ex; \
 # see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
 # (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
 	\
-	make -C /usr/src/redis -j "$(nproc)"; \
-	make -C /usr/src/redis install; \
+	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_AOF_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_AOF_NAME),g' /usr/src/redis/src/Makefile; \
+	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_RDB_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_RDB_NAME),g' /usr/src/redis/src/Makefile; \
+	\
+	make -C /usr/src/redis -j "$(nproc)" DEBUG="-s" install; \
 	\
 	rm -r /usr/src/redis; \
 	\

--- a/5.0/alpine/Dockerfile
+++ b/5.0/alpine/Dockerfile
@@ -44,7 +44,7 @@ RUN set -ex; \
 	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_AOF_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_AOF_NAME),g' /usr/src/redis/src/Makefile; \
 	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_RDB_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_RDB_NAME),g' /usr/src/redis/src/Makefile; \
 	\
-	make -C /usr/src/redis -j "$(nproc)" DEBUG="-s" install; \
+	make -C /usr/src/redis -j "$(nproc)" install; \
 	\
 	rm -r /usr/src/redis; \
 	\

--- a/5.0/alpine/Dockerfile
+++ b/5.0/alpine/Dockerfile
@@ -41,8 +41,10 @@ RUN set -ex; \
 # see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
 # (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
 	\
-	make -C /usr/src/redis -j "$(nproc)"; \
-	make -C /usr/src/redis install; \
+	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_AOF_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_AOF_NAME),g' /usr/src/redis/src/Makefile; \
+	sed -i -e 's,$(REDIS_INSTALL) $(REDIS_CHECK_RDB_NAME) $(INSTALL_BIN),@ln -sf $(REDIS_SERVER_NAME) $(INSTALL_BIN)/$(REDIS_CHECK_RDB_NAME),g' /usr/src/redis/src/Makefile; \
+	\
+	make -C /usr/src/redis -j "$(nproc)" DEBUG="-s" install; \
 	\
 	rm -r /usr/src/redis; \
 	\
@@ -52,8 +54,8 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --virtual .redis-rundeps $runDeps; \
-	apk del .build-deps; \
+	apk add --no-cache --virtual .redis-rundeps $runDeps; \
+	apk del --no-cache --purge .build-deps; \
 	\
 	redis-server --version
 


### PR DESCRIPTION
By default Redis is compiled with `-g -ggbd` options. It is controlled by
the `DEBUG` variable of a make file. Replacing it with `-s` helps a lot.

`redis-check-aof`, `redis-check-rdb` and `redis-sentinel` all can be
just symlinks to `redis-server` but for whatever reason all but `redis-sentinel`
are duplicates of `redis-server`.

There is a long hanging pull
request https://github.com/antirez/redis/pull/3494 and patches used by
package managers https://git.alpinelinux.org/cgit/aports/tree/main/redis/makefile-dont-duplicate-binary.patch
