### PR TITLE
Allow a new environment variable to change the UID of the docker

### DIFF
--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
-
+if [ ! -z ${FORCE_DAEMON_UID+x} ];then
+	usermod -u $FORCE_DAEMON_UID redis
+	find / -user 999 -exec chown -h redis {} 2>/dev/null \; && true
+fi
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then

--- a/5.0/docker-entrypoint.sh
+++ b/5.0/docker-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
-
+if [ ! -z ${FORCE_DAEMON_UID+x} ];then
+	usermod -u $FORCE_DAEMON_UID redis
+	find / -user 999 -exec chown -h redis {} 2>/dev/null \; && true
+fi
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then

--- a/6.0-rc/docker-entrypoint.sh
+++ b/6.0-rc/docker-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
-
+if [ ! -z ${FORCE_DAEMON_UID+x} ];then
+	usermod -u $FORCE_DAEMON_UID redis
+	find / -user 999 -exec chown -h redis {} 2>/dev/null \; && true
+fi
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then


### PR DESCRIPTION
### What does this Pull request solve ?

In some configurations, the UID is forced to be in a certain random range for security purpose. This could lead to some troubles for redis to run and  if it  needs to write on the disk with only write access to the user the container orchestrator choose for it. 

### How to solve this problem ?
As you can see, if the variable FORCE_DAEMON_UID is passed to the container, it will relabel the redis user with this UID and change all the files that belongs to the old redis UID to the new redis UID

Regards 
 