### PR TITLE
Change the redis group ID to 998 on alpine

### DIFF
--- a/5.0/alpine/Dockerfile
+++ b/5.0/alpine/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.12
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN addgroup -S -g 1000 redis && adduser -S -G redis -u 999 redis
-# alpine already has a gid 999, so we'll use the next id
+RUN addgroup -S -g 998 redis && adduser -S -G redis -u 999 redis
+# alpine already has a gid 999, so we'll use the previous id
 
 RUN apk add --no-cache \
 # grab su-exec for easy step-down from root

--- a/6.0/alpine/Dockerfile
+++ b/6.0/alpine/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.12
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN addgroup -S -g 1000 redis && adduser -S -G redis -u 999 redis
-# alpine already has a gid 999, so we'll use the next id
+RUN addgroup -S -g 998 redis && adduser -S -G redis -u 999 redis
+# alpine already has a gid 999, so we'll use the previous id
 
 RUN apk add --no-cache \
 # grab su-exec for easy step-down from root

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,8 +1,8 @@
 FROM alpine:3.12
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN addgroup -S -g 1000 redis && adduser -S -G redis -u 999 redis
-# alpine already has a gid 999, so we'll use the next id
+RUN addgroup -S -g 998 redis && adduser -S -G redis -u 999 redis
+# alpine already has a gid 999, so we'll use the previous id
 
 RUN apk add --no-cache \
 # grab su-exec for easy step-down from root


### PR DESCRIPTION
The GID 1000 is normally assigned as the default for the first user
created on linux distributions. Having it already in the image makes
it so injecting the host user and group into a custom image using redis
as base fail, requiring workarounds.

Having it use a GID below 1000 is preferable. Having a consistent user/group id all around would be best, for example postgres uses uid/gid 70, how about a similar setup here?

Here is a test image to illustrate the problem:
```dockerfile
FROM redis:6.0.5-alpine

ARG HOST_USER_UID=1000
ARG HOST_USER_GID=1000

RUN set -ex                                         && \
                                                       \
    echo 'Creating the notroot user and group'      && \
    addgroup -g $HOST_USER_GID -S notroot           && \
    adduser -u $HOST_USER_UID -G notroot -D notroot
USER notroot
```
Build it with the following command if you are user/group 1000
```sh
docker build . \
  --build-arg=HOST_USER_UID=`id -u` \
  --build-arg=HOST_USER_GID=`id -g` \
  -t redis
```
Or skip the args and let it build with the defaults.
```sh
docker build . -t redis
```

This might be a breaking change, no idea how it will affect existing users.