### PR TITLE
Specify which user process would run as

### DIFF
--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -116,5 +116,7 @@ WORKDIR /data
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+USER 999
+
 EXPOSE 6379
 CMD ["redis-server"]


### PR DESCRIPTION
Does `RUN groupadd -r -g 999 redis && useradd -r -g redis -u 999 redis` imply that the container would run as USER 999 ?