### PR TITLE
fix: zombie process.

### DIFF
--- a/5/alpine/Dockerfile
+++ b/5/alpine/Dockerfile
@@ -86,6 +86,7 @@ RUN set -eux; \
 	)"; \
 	apk add --no-network --virtual .redis-rundeps $runDeps; \
 	apk del --no-network .build-deps; \
+	apk add --no-cache coreutils; \
 	\
 	redis-cli --version; \
 	redis-server --version

--- a/6.0/alpine/Dockerfile
+++ b/6.0/alpine/Dockerfile
@@ -87,6 +87,7 @@ RUN set -eux; \
 	)"; \
 	apk add --no-network --virtual .redis-rundeps $runDeps; \
 	apk del --no-network .build-deps; \
+	apk add --no-cache coreutils; \
 	\
 	redis-cli --version; \
 	redis-server --version

--- a/6.2/alpine/Dockerfile
+++ b/6.2/alpine/Dockerfile
@@ -87,6 +87,7 @@ RUN set -eux; \
 	)"; \
 	apk add --no-network --virtual .redis-rundeps $runDeps; \
 	apk del --no-network .build-deps; \
+	apk add --no-cache coreutils; \
 	\
 	redis-cli --version; \
 	redis-server --version

--- a/7.0/alpine/Dockerfile
+++ b/7.0/alpine/Dockerfile
@@ -87,6 +87,7 @@ RUN set -eux; \
 	)"; \
 	apk add --no-network --virtual .redis-rundeps $runDeps; \
 	apk del --no-network .build-deps; \
+	apk add --no-cache coreutils; \
 	\
 	redis-cli --version; \
 	redis-server --version

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -89,6 +89,7 @@ RUN set -eux; \
 	)"; \
 	apk add --no-network --virtual .redis-rundeps $runDeps; \
 	apk del --no-network .build-deps; \
+	apk add --no-cache coreutils; \
 	\
 	redis-cli --version; \
 	redis-server --version


### PR DESCRIPTION
redis:6-alpine for K8s, readiness or liveness probe call 'timeout' ( busybox ) would cause zombie process.
```
livenessProbe:
  exec:
    command:
    - sh
    - -c
    - |-
      response=$(timeout -s 3 5 redis-cli --no-auth-warning -a $REDIS_PASSWORD -h localhost -p $REDIS_PORT ping)
      if [ "$response" != "PONG" ] && [ "$response" != "LOADING Redis is loading the dataset in memory" ]; then
        echo "$response"
        exit 1
      fi
  failureThreshold: 5
  initialDelaySeconds: 5
  periodSeconds: 5
  successThreshold: 1
  timeoutSeconds: 5
readinessProbe:
  exec:
    command:
    - sh
    - -c
    - |-
      response=$(timeout -s 3 5 redis-cli --no-auth-warning -a $REDIS_PASSWORD -h localhost -p $REDIS_PORT ping)
      if [ "$response" != "PONG" ]; then
        echo "$response"
        exit 1
      fi
  failureThreshold: 5
  initialDelaySeconds: 5
  periodSeconds: 5
  successThreshold: 1
  timeoutSeconds: 1
```

It is the same when I use docker.

alpine version `docker run --rm -it --name redis redis:6-alpine`, `docker exec -it redis sh`:

![image](https://user-images.githubusercontent.com/827020/183342663-ba26d05a-04d0-491f-ac34-1e47e25ec076.png)


but debian version `docker run --rm -it --name redis redis:6` `timeout` is ok:

![image](https://user-images.githubusercontent.com/827020/183342838-32c35ecc-8eb9-4a33-b290-50dc5a684c22.png)

so I think coreutils instead of busybox's `timeout`, could solve this issue?

