### PR TITLE
Add `HEALTHCHECK` instruction to `Dockerfile`

### DIFF
--- a/6.2/alpine/Dockerfile
+++ b/6.2/alpine/Dockerfile
@@ -139,3 +139,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["redis-server"]
+
+# Search for "PONG" instead of relying on the exit status because of
+# https://stackoverflow.com/a/71504657/815742.
+HEALTHCHECK --start-period=1s CMD redis-cli ping | grep ^PONG$

--- a/6.2/debian/Dockerfile
+++ b/6.2/debian/Dockerfile
@@ -148,3 +148,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["redis-server"]
+
+# Search for "PONG" instead of relying on the exit status because of
+# https://stackoverflow.com/a/71504657/815742.
+HEALTHCHECK --start-period=1s CMD redis-cli ping | grep ^PONG$

--- a/7.0/alpine/Dockerfile
+++ b/7.0/alpine/Dockerfile
@@ -139,3 +139,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["redis-server"]
+
+# Search for "PONG" instead of relying on the exit status because of
+# https://stackoverflow.com/a/71504657/815742.
+HEALTHCHECK --start-period=1s CMD redis-cli ping | grep ^PONG$

--- a/7.0/debian/Dockerfile
+++ b/7.0/debian/Dockerfile
@@ -148,3 +148,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["redis-server"]
+
+# Search for "PONG" instead of relying on the exit status because of
+# https://stackoverflow.com/a/71504657/815742.
+HEALTHCHECK --start-period=1s CMD redis-cli ping | grep ^PONG$

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -139,3 +139,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["redis-server"]
+
+# Search for "PONG" instead of relying on the exit status because of
+# https://stackoverflow.com/a/71504657/815742.
+HEALTHCHECK --start-period=1s CMD redis-cli ping | grep ^PONG$

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -148,3 +148,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["redis-server"]
+
+# Search for "PONG" instead of relying on the exit status because of
+# https://stackoverflow.com/a/71504657/815742.
+HEALTHCHECK --start-period=1s CMD redis-cli ping | grep ^PONG$

--- a/7.4-rc/alpine/Dockerfile
+++ b/7.4-rc/alpine/Dockerfile
@@ -139,3 +139,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["redis-server"]
+
+# Search for "PONG" instead of relying on the exit status because of
+# https://stackoverflow.com/a/71504657/815742.
+HEALTHCHECK --start-period=1s CMD redis-cli ping | grep ^PONG$

--- a/7.4-rc/debian/Dockerfile
+++ b/7.4-rc/debian/Dockerfile
@@ -148,3 +148,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["redis-server"]
+
+# Search for "PONG" instead of relying on the exit status because of
+# https://stackoverflow.com/a/71504657/815742.
+HEALTHCHECK --start-period=1s CMD redis-cli ping | grep ^PONG$

--- a/7.4/alpine/Dockerfile
+++ b/7.4/alpine/Dockerfile
@@ -139,3 +139,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["redis-server"]
+
+# Search for "PONG" instead of relying on the exit status because of
+# https://stackoverflow.com/a/71504657/815742.
+HEALTHCHECK --start-period=1s CMD redis-cli ping | grep ^PONG$

--- a/7.4/debian/Dockerfile
+++ b/7.4/debian/Dockerfile
@@ -148,3 +148,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["redis-server"]
+
+# Search for "PONG" instead of relying on the exit status because of
+# https://stackoverflow.com/a/71504657/815742.
+HEALTHCHECK --start-period=1s CMD redis-cli ping | grep ^PONG$

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -235,3 +235,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["redis-server"]
+
+# Search for "PONG" instead of relying on the exit status because of
+# https://stackoverflow.com/a/71504657/815742.
+HEALTHCHECK --start-period=1s CMD redis-cli ping | grep ^PONG$


### PR DESCRIPTION
The `Dockerfile` currently does not have a `HEALTHCHECK` instruction. Users of the Docker image currently need to add it manually (e.g. via Docker Compose). Instead, the `Dockerfile` itself should include the instruction.

To determine whether the service is healthy, one can use the [`PING`](https://redis.io/docs/latest/commands/ping/) command via the [Redis CLI](https://redis.io/docs/latest/develop/connect/cli/), which is already part of the image. The command “is useful for […] verifying the server's ability to serve data”.

Most of the default `HEALTHCHECK` [options](https://docs.docker.com/reference/dockerfile/#healthcheck) seem reasonable:
```
--interval=30s
--timeout=30s
--start-interval=5s
--retries=3
```

I set `--start-period=1s` because the default of `0s` is too quick for this program.

Users of the image can still override the `HEALTHCHECK` instruction if they want to customize the command or the options.