### PR TITLE
Add support for config fragments

### DIFF
--- a/6.2/alpine/Dockerfile
+++ b/6.2/alpine/Dockerfile
@@ -76,16 +76,6 @@ RUN set -eux; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
 	\
-# disable Redis protected mode [1] as it is unnecessary in context of Docker
-# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
-# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *1 *,.*[)],$' /usr/src/redis/src/config.c; \
-	sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' /usr/src/redis/src/config.c; \
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' /usr/src/redis/src/config.c; \
-# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to redis-server, [it assumes] you are going to specify everything"
-# see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
-# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
-	\
 # https://github.com/jemalloc/jemalloc/issues/467 -- we need to patch the "./configure" for the bundled jemalloc to match how Debian compiles, for compatibility
 # (also, we do cross-builds, so we need to embed the appropriate "--build=xxx" values to that "./configure" invocation)
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -128,7 +118,14 @@ RUN set -eux; \
 	apk del --no-network .build-deps; \
 	\
 	redis-cli --version; \
-	redis-server --version
+	redis-server --version;
+
+RUN set -ex; \
+	mkdir -p /usr/local/etc/redis/conf.d/; \
+	# Disable Redis protected mode [1] as it is unnecessary in context of Docker
+	# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
+	echo 'protected-mode no' > /usr/local/etc/redis/conf.d/docker.conf
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/6.2/alpine/docker-entrypoint.sh
+++ b/6.2/alpine/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
-	set -- redis-server "$@"
+	set -- redis-server "$@" '--include=/usr/local/etc/redis/conf.d/*.conf'
 fi
 
 # allow the container to be started with `--user`

--- a/6.2/debian/Dockerfile
+++ b/6.2/debian/Dockerfile
@@ -82,16 +82,6 @@ RUN set -eux; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
 	\
-# disable Redis protected mode [1] as it is unnecessary in context of Docker
-# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
-# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *1 *,.*[)],$' /usr/src/redis/src/config.c; \
-	sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' /usr/src/redis/src/config.c; \
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' /usr/src/redis/src/config.c; \
-# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to redis-server, [it assumes] you are going to specify everything"
-# see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
-# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
-	\
 # https://github.com/jemalloc/jemalloc/issues/467 -- we need to patch the "./configure" for the bundled jemalloc to match how Debian compiles, for compatibility
 # (also, we do cross-builds, so we need to embed the appropriate "--build=xxx" values to that "./configure" invocation)
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -137,7 +127,14 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
 	redis-cli --version; \
-	redis-server --version
+	redis-server --version;
+
+RUN set -ex; \
+	mkdir -p /usr/local/etc/redis/conf.d/; \
+	# Disable Redis protected mode [1] as it is unnecessary in context of Docker
+	# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
+	echo 'protected-mode no' > /usr/local/etc/redis/conf.d/docker.conf
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/6.2/debian/docker-entrypoint.sh
+++ b/6.2/debian/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
-	set -- redis-server "$@"
+	set -- redis-server "$@" '--include=/usr/local/etc/redis/conf.d/*.conf'
 fi
 
 # allow the container to be started with `--user`

--- a/7.0/alpine/Dockerfile
+++ b/7.0/alpine/Dockerfile
@@ -76,16 +76,6 @@ RUN set -eux; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
 	\
-# disable Redis protected mode [1] as it is unnecessary in context of Docker
-# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
-# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *1 *,.*[)],$' /usr/src/redis/src/config.c; \
-	sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' /usr/src/redis/src/config.c; \
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' /usr/src/redis/src/config.c; \
-# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to redis-server, [it assumes] you are going to specify everything"
-# see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
-# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
-	\
 # https://github.com/jemalloc/jemalloc/issues/467 -- we need to patch the "./configure" for the bundled jemalloc to match how Debian compiles, for compatibility
 # (also, we do cross-builds, so we need to embed the appropriate "--build=xxx" values to that "./configure" invocation)
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -128,7 +118,14 @@ RUN set -eux; \
 	apk del --no-network .build-deps; \
 	\
 	redis-cli --version; \
-	redis-server --version
+	redis-server --version;
+
+RUN set -ex; \
+	mkdir -p /usr/local/etc/redis/conf.d/; \
+	# Disable Redis protected mode [1] as it is unnecessary in context of Docker
+	# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
+	echo 'protected-mode no' > /usr/local/etc/redis/conf.d/docker.conf
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/7.0/alpine/docker-entrypoint.sh
+++ b/7.0/alpine/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
-	set -- redis-server "$@"
+	set -- redis-server "$@" '--include=/usr/local/etc/redis/conf.d/*.conf'
 fi
 
 # allow the container to be started with `--user`

--- a/7.0/debian/Dockerfile
+++ b/7.0/debian/Dockerfile
@@ -82,16 +82,6 @@ RUN set -eux; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
 	\
-# disable Redis protected mode [1] as it is unnecessary in context of Docker
-# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
-# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *1 *,.*[)],$' /usr/src/redis/src/config.c; \
-	sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' /usr/src/redis/src/config.c; \
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' /usr/src/redis/src/config.c; \
-# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to redis-server, [it assumes] you are going to specify everything"
-# see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
-# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
-	\
 # https://github.com/jemalloc/jemalloc/issues/467 -- we need to patch the "./configure" for the bundled jemalloc to match how Debian compiles, for compatibility
 # (also, we do cross-builds, so we need to embed the appropriate "--build=xxx" values to that "./configure" invocation)
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -137,7 +127,14 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
 	redis-cli --version; \
-	redis-server --version
+	redis-server --version;
+
+RUN set -ex; \
+	mkdir -p /usr/local/etc/redis/conf.d/; \
+	# Disable Redis protected mode [1] as it is unnecessary in context of Docker
+	# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
+	echo 'protected-mode no' > /usr/local/etc/redis/conf.d/docker.conf
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/7.0/debian/docker-entrypoint.sh
+++ b/7.0/debian/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
-	set -- redis-server "$@"
+	set -- redis-server "$@" '--include=/usr/local/etc/redis/conf.d/*.conf'
 fi
 
 # allow the container to be started with `--user`

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -76,16 +76,6 @@ RUN set -eux; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
 	\
-# disable Redis protected mode [1] as it is unnecessary in context of Docker
-# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
-# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *1 *,.*[)],$' /usr/src/redis/src/config.c; \
-	sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' /usr/src/redis/src/config.c; \
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' /usr/src/redis/src/config.c; \
-# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to redis-server, [it assumes] you are going to specify everything"
-# see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
-# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
-	\
 # https://github.com/jemalloc/jemalloc/issues/467 -- we need to patch the "./configure" for the bundled jemalloc to match how Debian compiles, for compatibility
 # (also, we do cross-builds, so we need to embed the appropriate "--build=xxx" values to that "./configure" invocation)
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -128,7 +118,14 @@ RUN set -eux; \
 	apk del --no-network .build-deps; \
 	\
 	redis-cli --version; \
-	redis-server --version
+	redis-server --version;
+
+RUN set -ex; \
+	mkdir -p /usr/local/etc/redis/conf.d/; \
+	# Disable Redis protected mode [1] as it is unnecessary in context of Docker
+	# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
+	echo 'protected-mode no' > /usr/local/etc/redis/conf.d/docker.conf
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/7.2/alpine/docker-entrypoint.sh
+++ b/7.2/alpine/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
-	set -- redis-server "$@"
+	set -- redis-server "$@" '--include=/usr/local/etc/redis/conf.d/*.conf'
 fi
 
 # allow the container to be started with `--user`

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -82,16 +82,6 @@ RUN set -eux; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
 	\
-# disable Redis protected mode [1] as it is unnecessary in context of Docker
-# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
-# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *1 *,.*[)],$' /usr/src/redis/src/config.c; \
-	sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' /usr/src/redis/src/config.c; \
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' /usr/src/redis/src/config.c; \
-# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to redis-server, [it assumes] you are going to specify everything"
-# see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
-# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
-	\
 # https://github.com/jemalloc/jemalloc/issues/467 -- we need to patch the "./configure" for the bundled jemalloc to match how Debian compiles, for compatibility
 # (also, we do cross-builds, so we need to embed the appropriate "--build=xxx" values to that "./configure" invocation)
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -137,7 +127,14 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
 	redis-cli --version; \
-	redis-server --version
+	redis-server --version;
+
+RUN set -ex; \
+	mkdir -p /usr/local/etc/redis/conf.d/; \
+	# Disable Redis protected mode [1] as it is unnecessary in context of Docker
+	# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
+	echo 'protected-mode no' > /usr/local/etc/redis/conf.d/docker.conf
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/7.2/debian/docker-entrypoint.sh
+++ b/7.2/debian/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
-	set -- redis-server "$@"
+	set -- redis-server "$@" '--include=/usr/local/etc/redis/conf.d/*.conf'
 fi
 
 # allow the container to be started with `--user`

--- a/7.4-rc/alpine/Dockerfile
+++ b/7.4-rc/alpine/Dockerfile
@@ -76,16 +76,6 @@ RUN set -eux; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
 	\
-# disable Redis protected mode [1] as it is unnecessary in context of Docker
-# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
-# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *1 *,.*[)],$' /usr/src/redis/src/config.c; \
-	sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' /usr/src/redis/src/config.c; \
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' /usr/src/redis/src/config.c; \
-# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to redis-server, [it assumes] you are going to specify everything"
-# see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
-# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
-	\
 # https://github.com/jemalloc/jemalloc/issues/467 -- we need to patch the "./configure" for the bundled jemalloc to match how Debian compiles, for compatibility
 # (also, we do cross-builds, so we need to embed the appropriate "--build=xxx" values to that "./configure" invocation)
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -128,7 +118,14 @@ RUN set -eux; \
 	apk del --no-network .build-deps; \
 	\
 	redis-cli --version; \
-	redis-server --version
+	redis-server --version;
+
+RUN set -ex; \
+	mkdir -p /usr/local/etc/redis/conf.d/; \
+	# Disable Redis protected mode [1] as it is unnecessary in context of Docker
+	# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
+	echo 'protected-mode no' > /usr/local/etc/redis/conf.d/docker.conf
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/7.4-rc/alpine/docker-entrypoint.sh
+++ b/7.4-rc/alpine/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
-	set -- redis-server "$@"
+	set -- redis-server "$@" '--include=/usr/local/etc/redis/conf.d/*.conf'
 fi
 
 # allow the container to be started with `--user`

--- a/7.4-rc/debian/Dockerfile
+++ b/7.4-rc/debian/Dockerfile
@@ -82,16 +82,6 @@ RUN set -eux; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
 	\
-# disable Redis protected mode [1] as it is unnecessary in context of Docker
-# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
-# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *1 *,.*[)],$' /usr/src/redis/src/config.c; \
-	sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' /usr/src/redis/src/config.c; \
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' /usr/src/redis/src/config.c; \
-# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to redis-server, [it assumes] you are going to specify everything"
-# see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
-# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
-	\
 # https://github.com/jemalloc/jemalloc/issues/467 -- we need to patch the "./configure" for the bundled jemalloc to match how Debian compiles, for compatibility
 # (also, we do cross-builds, so we need to embed the appropriate "--build=xxx" values to that "./configure" invocation)
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -137,7 +127,14 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
 	redis-cli --version; \
-	redis-server --version
+	redis-server --version;
+
+RUN set -ex; \
+	mkdir -p /usr/local/etc/redis/conf.d/; \
+	# Disable Redis protected mode [1] as it is unnecessary in context of Docker
+	# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
+	echo 'protected-mode no' > /usr/local/etc/redis/conf.d/docker.conf
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/7.4-rc/debian/docker-entrypoint.sh
+++ b/7.4-rc/debian/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
-	set -- redis-server "$@"
+	set -- redis-server "$@" '--include=/usr/local/etc/redis/conf.d/*.conf'
 fi
 
 # allow the container to be started with `--user`

--- a/7.4/alpine/Dockerfile
+++ b/7.4/alpine/Dockerfile
@@ -76,16 +76,6 @@ RUN set -eux; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
 	\
-# disable Redis protected mode [1] as it is unnecessary in context of Docker
-# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
-# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *1 *,.*[)],$' /usr/src/redis/src/config.c; \
-	sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' /usr/src/redis/src/config.c; \
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' /usr/src/redis/src/config.c; \
-# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to redis-server, [it assumes] you are going to specify everything"
-# see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
-# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
-	\
 # https://github.com/jemalloc/jemalloc/issues/467 -- we need to patch the "./configure" for the bundled jemalloc to match how Debian compiles, for compatibility
 # (also, we do cross-builds, so we need to embed the appropriate "--build=xxx" values to that "./configure" invocation)
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -128,7 +118,14 @@ RUN set -eux; \
 	apk del --no-network .build-deps; \
 	\
 	redis-cli --version; \
-	redis-server --version
+	redis-server --version;
+
+RUN set -ex; \
+	mkdir -p /usr/local/etc/redis/conf.d/; \
+	# Disable Redis protected mode [1] as it is unnecessary in context of Docker
+	# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
+	echo 'protected-mode no' > /usr/local/etc/redis/conf.d/docker.conf
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/7.4/alpine/docker-entrypoint.sh
+++ b/7.4/alpine/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
-	set -- redis-server "$@"
+	set -- redis-server "$@" '--include=/usr/local/etc/redis/conf.d/*.conf'
 fi
 
 # allow the container to be started with `--user`

--- a/7.4/debian/Dockerfile
+++ b/7.4/debian/Dockerfile
@@ -82,16 +82,6 @@ RUN set -eux; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
 	\
-# disable Redis protected mode [1] as it is unnecessary in context of Docker
-# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
-# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *1 *,.*[)],$' /usr/src/redis/src/config.c; \
-	sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' /usr/src/redis/src/config.c; \
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' /usr/src/redis/src/config.c; \
-# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to redis-server, [it assumes] you are going to specify everything"
-# see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
-# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
-	\
 # https://github.com/jemalloc/jemalloc/issues/467 -- we need to patch the "./configure" for the bundled jemalloc to match how Debian compiles, for compatibility
 # (also, we do cross-builds, so we need to embed the appropriate "--build=xxx" values to that "./configure" invocation)
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -137,7 +127,14 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
 	redis-cli --version; \
-	redis-server --version
+	redis-server --version;
+
+RUN set -ex; \
+	mkdir -p /usr/local/etc/redis/conf.d/; \
+	# Disable Redis protected mode [1] as it is unnecessary in context of Docker
+	# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
+	echo 'protected-mode no' > /usr/local/etc/redis/conf.d/docker.conf
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/7.4/debian/docker-entrypoint.sh
+++ b/7.4/debian/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
-	set -- redis-server "$@"
+	set -- redis-server "$@" '--include=/usr/local/etc/redis/conf.d/*.conf'
 fi
 
 # allow the container to be started with `--user`

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -158,16 +158,6 @@ RUN set -eux; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
 	\
-# disable Redis protected mode [1] as it is unnecessary in context of Docker
-# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
-# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *1 *,.*[)],$' /usr/src/redis/src/config.c; \
-	sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' /usr/src/redis/src/config.c; \
-	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' /usr/src/redis/src/config.c; \
-# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to redis-server, [it assumes] you are going to specify everything"
-# see also https://github.com/docker-library/redis/issues/4#issuecomment-50780840
-# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
-	\
 # https://github.com/jemalloc/jemalloc/issues/467 -- we need to patch the "./configure" for the bundled jemalloc to match how Debian compiles, for compatibility
 # (also, we do cross-builds, so we need to embed the appropriate "--build=xxx" values to that "./configure" invocation)
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -224,7 +214,14 @@ RUN set -eux; \
 {{ ) end -}}
 	\
 	redis-cli --version; \
-	redis-server --version
+	redis-server --version;
+
+RUN set -ex; \
+	mkdir -p /usr/local/etc/redis/conf.d/; \
+	# Disable Redis protected mode [1] as it is unnecessary in context of Docker
+	# [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
+	# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
+	echo 'protected-mode no' > /usr/local/etc/redis/conf.d/docker.conf
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # first arg is `-f` or `--some-option`
 # or first arg is `something.conf`
 if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
-	set -- redis-server "$@"
+	set -- redis-server "$@" '--include=/usr/local/etc/redis/conf.d/*.conf'
 fi
 
 # allow the container to be started with `--user`


### PR DESCRIPTION
Using this approach, you can easily override our custom settings or add your own like this:

```yaml
services:
  redis:
    image: redis:test
    configs:
      - source: redis_config
        target: /usr/local/etc/redis/conf.d/my.conf

configs:
  redis_config:
    content: |
      port 8000
```

Which yields

```
[+] Running 2/0
 ✔ Network redis_default    Created                                                                                                                                                                        0.0s 
 ✔ Container redis-redis-1  Created                                                                                                                                                                        0.0s 
Attaching to redis-1
redis-1  | 1:C 06 Feb 2025 21:16:42.399 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
redis-1  | 1:C 06 Feb 2025 21:16:42.399 * Redis version=7.4.2, bits=64, commit=00000000, modified=0, pid=1, just started
redis-1  | 1:C 06 Feb 2025 21:16:42.399 * Configuration loaded
redis-1  | 1:M 06 Feb 2025 21:16:42.399 * monotonic clock: POSIX clock_gettime
redis-1  | 1:M 06 Feb 2025 21:16:42.399 * Running mode=standalone, port=8000.
redis-1  | 1:M 06 Feb 2025 21:16:42.400 * Server initialized
redis-1  | 1:M 06 Feb 2025 21:16:42.400 * Ready to accept connections tcp
```