### PR TITLE
Removed redis binaries symlinks redundance 

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -109,17 +109,6 @@ RUN set -eux; \
 	make -C /usr/src/redis -j "$(nproc)" all; \
 	make -C /usr/src/redis install; \
 	\
-# TODO https://github.com/redis/redis/pull/3494 (deduplicate "redis-server" copies)
-	serverMd5="$(md5sum /usr/local/bin/redis-server | cut -d' ' -f1)"; export serverMd5; \
-	find /usr/local/bin/redis* -maxdepth 0 \
-		-type f -not -name redis-server \
-		-exec sh -eux -c ' \
-			md5="$(md5sum "$1" | cut -d" " -f1)"; \
-			test "$md5" = "$serverMd5"; \
-		' -- '{}' ';' \
-		-exec ln -svfT 'redis-server' '{}' ';' \
-	; \
-	\
 	make -C /usr/src/redis distclean; \
 	rm -r /usr/src/redis; \
 	\

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -89,17 +89,6 @@ RUN set -eux; \
 	make -C /usr/src/redis -j "$(nproc)" all; \
 	make -C /usr/src/redis install; \
 	\
-# TODO https://github.com/redis/redis/pull/3494 (deduplicate "redis-server" copies)
-	serverMd5="$(md5sum /usr/local/bin/redis-server | cut -d' ' -f1)"; export serverMd5; \
-	find /usr/local/bin/redis* -maxdepth 0 \
-		-type f -not -name redis-server \
-		-exec sh -eux -c ' \
-			md5="$(md5sum "$1" | cut -d" " -f1)"; \
-			test "$md5" = "$serverMd5"; \
-		' -- '{}' ';' \
-		-exec ln -svfT 'redis-server' '{}' ';' \
-	; \
-	\
 	make -C /usr/src/redis distclean; \
 	rm -r /usr/src/redis; \
 	\


### PR DESCRIPTION
The deleted code is redundant, symlink for `redis-check-aof` and `redis-check-rdb` are created during `make install`.
This has been added at [redis/redis](https://github.com/redis/redis/pull/5745#issue-395534718)

I've also built Alpine and Debian images and confirmed.