### PR TITLE
ci(ghcr): add deploy on GitHub

### DIFF
--- a/.github/workflows/publish-to-ghcr.yml
+++ b/.github/workflows/publish-to-ghcr.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - release/*
 
 jobs:
   build-and-push:

--- a/.github/workflows/publish-to-ghcr.yml
+++ b/.github/workflows/publish-to-ghcr.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - release/*
+    tags:        
+      - '*' 
 
 jobs:
   build-and-push:

--- a/.github/workflows/publish-to-ghcr.yml
+++ b/.github/workflows/publish-to-ghcr.yml
@@ -35,3 +35,4 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/redis:latest
             ghcr.io/${{ github.repository_owner }}/redis:${{ github.sha }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-to-ghcr.yml
+++ b/.github/workflows/publish-to-ghcr.yml
@@ -1,0 +1,37 @@
+name: Publish Docker Images to GHCR
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/redis:latest
+            ghcr.io/${{ github.repository_owner }}/redis:${{ github.sha }}

--- a/.github/workflows/publish-to-ghcr.yml
+++ b/.github/workflows/publish-to-ghcr.yml
@@ -33,6 +33,5 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/redis:latest
             ghcr.io/${{ github.repository_owner }}/redis:${{ github.sha }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-to-ghcr.yml
+++ b/.github/workflows/publish-to-ghcr.yml
@@ -3,7 +3,7 @@ name: Publish Docker Images to GHCR
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build-and-push:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the publishing of Docker images to the GitHub Container Registry (GHCR). The workflow is triggered on pushes to the `main` branch and includes steps for building and pushing Docker images.

### New GitHub Actions Workflow:

* [`.github/workflows/publish-to-ghcr.yml`](diffhunk://#diff-cd1c8dcae4456d5ffcf205b278a47c656645b94c05b0f4200032df2ffc58b26dR1-R37): Added a workflow named "Publish Docker Images to GHCR" that builds and pushes Docker images to GHCR. It includes steps for checking out the repository, logging into GHCR, setting up QEMU and Docker Buildx, and building and pushing Docker images with appropriate tags.