### PR TITLE
Bump Redis version to 8.2.1

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -14,8 +14,8 @@ RUN set -eux; \
 # we need setpriv package as busybox provides very limited functionality
 		setpriv \
 	;
-ENV REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/tags/8.2.0.tar.gz
-ENV REDIS_DOWNLOAD_SHA=c64219bdcba407d18c8dde1fb87b86945aebf75e60f5b44ff463785a962645ed
+ENV REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-8.2.1.tar.gz
+ENV REDIS_DOWNLOAD_SHA=e2c1cb9dd4180a35b943b85dfc7dcdd42566cdbceca37d0d0b14c21731582d3e
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -14,8 +14,8 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/tags/8.2.0.tar.gz
-ENV REDIS_DOWNLOAD_SHA=c64219bdcba407d18c8dde1fb87b86945aebf75e60f5b44ff463785a962645ed
+ENV REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-8.2.1.tar.gz
+ENV REDIS_DOWNLOAD_SHA=e2c1cb9dd4180a35b943b85dfc7dcdd42566cdbceca37d0d0b14c21731582d3e
 RUN set -eux; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \


### PR DESCRIPTION
This PR bumps the Redis version from 8.2.1-int to the official Redis 8.2.1 release.

## Changes
- Update `REDIS_DOWNLOAD_URL` to use the official Redis 8.2.1 release tarball from `http://download.redis.io/releases/redis-8.2.1.tar.gz`
- Update `REDIS_DOWNLOAD_SHA` to the correct SHA256 hash: `e2c1cb9dd4180a35b943b85dfc7dcdd42566cdbceca37d0d0b14c21731582d3e`
- Switch from internal 8.2.1-int tag to official 8.2.1 release

## Files Modified
- `alpine/Dockerfile`
- `debian/Dockerfile`

## Verification
The SHA256 hash was verified by downloading the tarball directly:
```bash
curl -s http://download.redis.io/releases/redis-8.2.1.tar.gz | sha256sum
# e2c1cb9dd4180a35b943b85dfc7dcdd42566cdbceca37d0d0b14c21731582d3e
```

## Release Information
This change aligns the Docker images with the official Redis 8.2.1 release:
- **Release Date**: August 18, 2025
- **Commit SHA**: cd0b129
- **Release Notes**: https://github.com/redis/redis/releases/tag/8.2.1

### Bug Fixes in 8.2.1
- #14240 INFO KEYSIZES - potential incorrect histogram updates on cluster mode with modules
- #14274 Disable Active Defrag during flushing replica
- #14276 XADD or XTRIM can crash the server after loading RDB
- #Q6601 Potential crash when running FLUSHDB (MOD-10681)

### Performance and Resource Utilization
- Query Engine - LeanVec and LVQ proprietary Intel optimizations were removed from Redis Open Source
- #Q6621 Fix regression in INFO (MOD-10779)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author