### PR TITLE
Replace custom_ref_type with auto detect archive URL

### DIFF
--- a/.github/actions/build-and-tag-locally/action.yml
+++ b/.github/actions/build-and-tag-locally/action.yml
@@ -35,9 +35,6 @@ inputs:
   redistimeseries_version:
     description: 'Redistimeseries version to build'
     required: false
-  custom_ref_type:
-    description: 'Type of custom release, branch tag or commit. Empty for release'
-    required: false
   run_type:
     description: 'Run type, either release, pr, nightly, unstable or custom'
     required: true
@@ -109,16 +106,24 @@ runs:
     - name: Redis release archive
       shell: bash
       if: inputs.run_type != 'release' && inputs.run_type != 'pr'
+      env:
+        TAG: ${{ inputs.release_tag }}
       run: |
-        if [[ "${{ inputs.custom_ref_type }}" == "branch" ]]; then
-            echo "REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/heads/${{ inputs.release_tag }}.tar.gz" | tee -a "$GITHUB_ENV"
-        elif [[ "${{ inputs.custom_ref_type }}" == "tag" ]]; then
-            echo "REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/tags/${{ inputs.release_tag }}.tar.gz" | tee -a "$GITHUB_ENV"
-        elif [[ "${{ inputs.custom_ref_type }}" == "commit" ]]; then
-            echo "REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/${{ inputs.release_tag }}.tar.gz" | tee -a "$GITHUB_ENV"
-        else
-            echo "Wrong custom_build type, available options are tag, branch and commit"
-            exit 1
+        # Figure out the correct URL for the Redis release archive
+        REDIS_DOWNLOAD_URL=""
+        for URL in \
+          "https://github.com/redis/redis/archive/refs/tags/$TAG.tar.gz" \
+          "https://github.com/redis/redis/archive/refs/heads/$TAG.tar.gz" \
+          "https://github.com/redis/redis/archive/$TAG.tar.gz"; do
+          if curl --fail -sS -IL -w "%{http_code} %{url}\n" "$URL" -o /dev/null; then
+            REDIS_DOWNLOAD_URL=$URL
+            echo "REDIS_DOWNLOAD_URL=$URL" | tee -a "$GITHUB_ENV"
+            break
+          fi
+        done
+        if [ -z "$REDIS_DOWNLOAD_URL" ]; then
+          echo "Failed to find Redis release archive"
+          exit 1
         fi
 
     - name: Build

--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -28,10 +28,6 @@ on:
         required: false
         type: boolean
         default: false
-      custom_ref_type:
-        description: 'Custom type, either branch, tag or commit. Empty for releases'
-        required: false
-        type: string
       run_type:
         description: 'Run type, either release, pr, unstable, nightly or custom'
         required: false
@@ -95,7 +91,6 @@ jobs:
           redisjson_version: ${{ inputs.redisjson_version }}
           redisbloom_version: ${{ inputs.redisbloom_version }}
           redistimeseries_version: ${{ inputs.redistimeseries_version }}
-          custom_ref_type: ${{ inputs.custom_ref_type }}
           run_type: ${{ inputs.run_type }}
 
   collect-images-metadata:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,5 +28,4 @@ jobs:
       redisjson_version: master
       redisbloom_version: master
       redistimeseries_version: master
-      custom_ref_type: branch
       run_type: unstable

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -26,9 +26,6 @@ on:
       redistimeseries_version:
         description: 'Redistimeseries version to build'
         required: false
-      custom_ref_type:
-        description: 'Custom type, either branch, tag or commit. Empty for releases'
-        required: false
       run_type:
         description: 'Run type, either release, unstable or custom'
         required: true
@@ -84,7 +81,6 @@ jobs:
       redisjson_version: ${{ github.event.inputs.redisjson_version }}
       redisbloom_version: ${{ github.event.inputs.redisbloom_version }}
       redistimeseries_version: ${{ github.event.inputs.redistimeseries_version }}
-      custom_ref_type: ${{ github.event.inputs.custom_ref_type }}
       run_type: ${{ github.event.inputs.run_type }}
 
   merge-back-to-release-branch:


### PR DESCRIPTION
Sequentally test whether does tag, branch or commit archive exist for specified release_tag.

Detection output looks like this:

```
Run # Figure out the correct URL for the Redis release archive
curl: (22) The requested URL returned error: 404
404 https://github.com/redis/redis/archive/refs/tags/unstable.tar.gz
200 https://github.com/redis/redis/archive/refs/heads/unstable.tar.gz
REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/heads/unstable.tar.gz
```