### PR TITLE
Remove custom_ref_type since it's autodetected

### DIFF
--- a/.github/workflows/nightly-unstable-package.yml
+++ b/.github/workflows/nightly-unstable-package.yml
@@ -15,6 +15,5 @@ jobs:
       redisjson_version: master
       redisbloom_version: master
       redistimeseries_version: master
-      custom_ref_type: branch
       run_type: nightly
 


### PR DESCRIPTION
See https://github.com/redis/docker-library-redis/pull/498