### PR TITLE
Fix docker-entrypoint.sh loadmodule twice

### DIFF
--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -156,6 +156,11 @@ if [ "$IS_REDIS_SERVER" ] && ! [ "$IS_REDIS_SENTINEL" ]; then
 	elif [ -n "$(ls -A $modules_dir 2>/dev/null)" ]; then
 		for module in "$modules_dir"/*.so; 
 		do
+			if [ -n "$CONFIG" ] && [ -n "$(grep "loadmodule $module" "$CONFIG")" ]; then
+				echo "Skipping module $module: --loadmodule flag is already present in config file $CONFIG"
+				continue
+			fi 
+			
 			if [ ! -s "$module" ]; then
 				echo "Skipping module $module: file has no size."
 				continue

--- a/debian/docker-entrypoint.sh
+++ b/debian/docker-entrypoint.sh
@@ -156,6 +156,11 @@ if [ "$IS_REDIS_SERVER" ] && ! [ "$IS_REDIS_SENTINEL" ]; then
 	elif [ -n "$(ls -A $modules_dir 2>/dev/null)" ]; then
 		for module in "$modules_dir"/*.so; 
 		do
+			if [ -n "$CONFIG" ] && [ -n "$(grep "loadmodule $module" "$CONFIG")" ]; then
+				echo "Skipping module $module: --loadmodule flag is already present in config file $CONFIG"
+				continue
+			fi 
+
 			if [ ! -s "$module" ]; then
 				echo "Skipping module $module: file has no size."
 				continue


### PR DESCRIPTION
This PR fix #468

If redis container is started with  a config file, the current `docker-entrypoint.sh` script will still generate the `redis-server` command with `--loadmodule` flag. 
If a `CONFIG REWRITE` is issued (for example, by Sentinel client), the `loadmodule` entries will be written to the config file. Restarting the container will then result in a module initialization error (due to modules being loaded twice).

This PR add a check to skip `--loadmodule` flag if the container is started with a config file, and the `loadmodule $module` entry is already present. 