### PR TITLE
Use "c" instead of "s" in sed to handle branch names with slashes

### DIFF
--- a/alpine/Dockerfile.j2
+++ b/alpine/Dockerfile.j2
@@ -128,16 +128,16 @@ RUN set -eux; \
 
 		# Update modules versions
 		if [ -n "$REDISEARCH_VERSION" ]; then \
-			sed -i "s/^MODULE_VERSION = .*/MODULE_VERSION = $REDISEARCH_VERSION/" /usr/src/redis/modules/redisearch/Makefile; \
+			sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISEARCH_VERSION" /usr/src/redis/modules/redisearch/Makefile; \
 		fi; \
 		if [ -n "$REDISJSON_VERSION" ]; then \
-			sed -i "s/^MODULE_VERSION = .*/MODULE_VERSION = $REDISJSON_VERSION/" /usr/src/redis/modules/redisjson/Makefile; \
+			sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISJSON_VERSION" /usr/src/redis/modules/redisjson/Makefile; \
 		fi; \
 		if [ -n "$REDISBLOOM_VERSION" ]; then \
-			sed -i "s/^MODULE_VERSION = .*/MODULE_VERSION = $REDISBLOOM_VERSION/" /usr/src/redis/modules/redisbloom/Makefile; \
+			sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISBLOOM_VERSION" /usr/src/redis/modules/redisbloom/Makefile; \
 		fi; \
 		if [ -n "$REDISTIMESERIES_VERSION" ]; then \
-			sed -i "s/^MODULE_VERSION = .*/MODULE_VERSION = $REDISTIMESERIES_VERSION/" /usr/src/redis/modules/redistimeseries/Makefile; \
+			sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISTIMESERIES_VERSION" /usr/src/redis/modules/redistimeseries/Makefile; \
 		fi; \
 
 	{%- endif %}

--- a/debian/Dockerfile.j2
+++ b/debian/Dockerfile.j2
@@ -82,16 +82,16 @@ RUN set -eux; \
 	\
 	# Update modules versions
 	if [ -n "$REDISEARCH_VERSION" ]; then \
-		sed -i "s/^MODULE_VERSION = .*/MODULE_VERSION = $REDISEARCH_VERSION/" /usr/src/redis/modules/redisearch/Makefile; \
+		sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISEARCH_VERSION" /usr/src/redis/modules/redisearch/Makefile; \
 	fi; \
 	if [ -n "$REDISJSON_VERSION" ]; then \
-		sed -i "s/^MODULE_VERSION = .*/MODULE_VERSION = $REDISJSON_VERSION/" /usr/src/redis/modules/redisjson/Makefile; \
+		sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISJSON_VERSION" /usr/src/redis/modules/redisjson/Makefile; \
 	fi; \
 	if [ -n "$REDISBLOOM_VERSION" ]; then \
-		sed -i "s/^MODULE_VERSION = .*/MODULE_VERSION = $REDISBLOOM_VERSION/" /usr/src/redis/modules/redisbloom/Makefile; \
+		sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISBLOOM_VERSION" /usr/src/redis/modules/redisbloom/Makefile; \
 	fi; \
 	if [ -n "$REDISTIMESERIES_VERSION" ]; then \
-		sed -i "s/^MODULE_VERSION = .*/MODULE_VERSION = $REDISTIMESERIES_VERSION/" /usr/src/redis/modules/redistimeseries/Makefile; \
+		sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISTIMESERIES_VERSION" /usr/src/redis/modules/redistimeseries/Makefile; \
 	fi; \
 
 	{%- endif %}


### PR DESCRIPTION
c would just replace whole string with literals folowing the command without involving regexp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small build-script change limited to Docker image module version patching; low blast radius aside from potential build-time differences if Makefile formatting varies.
> 
> **Overview**
> Updates the Alpine and Debian `Dockerfile.j2` templates to change how Redis module versions are injected during `custom_build`.
> 
> The `sed` commands that set `MODULE_VERSION` in module Makefiles now use the line-replace (`c`) form instead of a regex substitution, avoiding failures when version strings contain characters like `/` (e.g., branch names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 724a0e9a1a92867610632ce96eeff97b53235c08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->