### PR TITLE
Removes redundant symlink creation

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -114,18 +114,6 @@ RUN set -eux; \
 	fi; \
 	make -C /usr/src/redis -j "$(nproc)" all; \
 	make -C /usr/src/redis install; \
-	\
-# TODO https://github.com/redis/redis/pull/3494 (deduplicate "redis-server" copies)
-	serverMd5="$(md5sum /usr/local/bin/redis-server | cut -d' ' -f1)"; export serverMd5; \
-	find /usr/local/bin/redis* -maxdepth 0 \
-		-type f -not -name redis-server \
-		-exec sh -eux -c ' \
-			md5="$(md5sum "$1" | cut -d" " -f1)"; \
-			test "$md5" = "$serverMd5"; \
-		' -- '{}' ';' \
-		-exec ln -svfT 'redis-server' '{}' ';' \
-	; \
-	\
 	make -C /usr/src/redis distclean; \
 	rm -r /usr/src/redis; \
 	\

--- a/alpine/Dockerfile.j2
+++ b/alpine/Dockerfile.j2
@@ -148,18 +148,6 @@ RUN set -eux; \
 	fi; \
 	make -C /usr/src/redis -j "$(nproc)" all; \
 	make -C /usr/src/redis install; \
-	\
-# TODO https://github.com/redis/redis/pull/3494 (deduplicate "redis-server" copies)
-	serverMd5="$(md5sum /usr/local/bin/redis-server | cut -d' ' -f1)"; export serverMd5; \
-	find /usr/local/bin/redis* -maxdepth 0 \
-		-type f -not -name redis-server \
-		-exec sh -eux -c ' \
-			md5="$(md5sum "$1" | cut -d" " -f1)"; \
-			test "$md5" = "$serverMd5"; \
-		' -- '{}' ';' \
-		-exec ln -svfT 'redis-server' '{}' ';' \
-	; \
-	\
 	make -C /usr/src/redis distclean; \
 	rm -r /usr/src/redis; \
 	\

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -89,18 +89,6 @@ RUN set -eux; \
 	export BUILD_TLS=yes; \
 	make -C /usr/src/redis -j "$(nproc)" all; \
 	make -C /usr/src/redis install; \
-	\
-# TODO https://github.com/redis/redis/pull/3494 (deduplicate "redis-server" copies)
-	serverMd5="$(md5sum /usr/local/bin/redis-server | cut -d' ' -f1)"; export serverMd5; \
-	find /usr/local/bin/redis* -maxdepth 0 \
-		-type f -not -name redis-server \
-		-exec sh -eux -c ' \
-			md5="$(md5sum "$1" | cut -d" " -f1)"; \
-			test "$md5" = "$serverMd5"; \
-		' -- '{}' ';' \
-		-exec ln -svfT 'redis-server' '{}' ';' \
-	; \
-	\
 	make -C /usr/src/redis distclean; \
 	rm -r /usr/src/redis; \
 	\

--- a/debian/Dockerfile.j2
+++ b/debian/Dockerfile.j2
@@ -123,18 +123,6 @@ RUN set -eux; \
 	export BUILD_TLS=yes; \
 	make -C /usr/src/redis -j "$(nproc)" all; \
 	make -C /usr/src/redis install; \
-	\
-# TODO https://github.com/redis/redis/pull/3494 (deduplicate "redis-server" copies)
-	serverMd5="$(md5sum /usr/local/bin/redis-server | cut -d' ' -f1)"; export serverMd5; \
-	find /usr/local/bin/redis* -maxdepth 0 \
-		-type f -not -name redis-server \
-		-exec sh -eux -c ' \
-			md5="$(md5sum "$1" | cut -d" " -f1)"; \
-			test "$md5" = "$serverMd5"; \
-		' -- '{}' ';' \
-		-exec ln -svfT 'redis-server' '{}' ';' \
-	; \
-	\
 	make -C /usr/src/redis distclean; \
 	rm -r /usr/src/redis; \
 	\


### PR DESCRIPTION
This is adaptation of https://github.com/redis/docker-library-redis/pull/438

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only change that removes redundant filesystem manipulation after install; main risk is unexpected differences in the final set of `redis*` binaries/links.
> 
> **Overview**
> Removes the post-install step in the Alpine and Debian Dockerfiles (and their `.j2` templates) that MD5-compared `redis*` binaries and forcibly symlinked them to `redis-server`.
> 
> Image builds now leave the installed Redis binaries as produced by `make install`, simplifying the build stage and eliminating the extra `find`/`ln -sf` logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9e5753676fe47680c22fe0314dea842e89becdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->