### PR TITLE
Add RELEASE_VERSION env to the images for 8.x series

### DIFF
--- a/.github/actions/apply-docker-version/apply-docker-version.sh
+++ b/.github/actions/apply-docker-version/apply-docker-version.sh
@@ -31,6 +31,7 @@ echo "REDIS_ARCHIVE_SHA: $REDIS_ARCHIVE_SHA"
 echo "Updating .redis.version.json..."
 cat > .redis.version.json <<EOF
 {
+	"release_tag": "$TAG",
 	"redis_download_url": "$REDIS_ARCHIVE_URL",
 	"redis_download_sha": "$REDIS_ARCHIVE_SHA"
 }

--- a/.redis.version.json
+++ b/.redis.version.json
@@ -1,4 +1,5 @@
 {
+	"release_tag": "8.6-rc1",
 	"redis_download_url": "https://github.com/redis/redis/archive/refs/tags/8.6-rc1.tar.gz",
 	"redis_download_sha": "dc387a093cb4f956953492eeb613e833b53ee23a45625bde01cc6d2497a5c0e7"
 }

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -14,6 +14,7 @@ RUN set -eux; \
 # we need setpriv package as busybox provides very limited functionality
 		setpriv \
 	;
+ENV REDIS_VERSION=8.6-rc1
 ARG REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/tags/8.6-rc1.tar.gz
 ARG REDIS_DOWNLOAD_SHA=dc387a093cb4f956953492eeb613e833b53ee23a45625bde01cc6d2497a5c0e7
 RUN set -eux; \

--- a/alpine/Dockerfile.j2
+++ b/alpine/Dockerfile.j2
@@ -14,6 +14,9 @@ RUN set -eux; \
 # we need setpriv package as busybox provides very limited functionality
 		setpriv \
 	;
+{% if release_tag %}
+ENV REDIS_VERSION={{ release_tag }}
+{% endif %}
 ARG REDIS_DOWNLOAD_URL={{ redis_download_url | required("redis_download_url is required") }}
 {% if not custom_build %}
 ARG REDIS_DOWNLOAD_SHA={{ redis_download_sha | required("redis_download_sha is required") }}

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -14,6 +14,7 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
+ENV REDIS_VERSION=8.6-rc1
 ARG REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/tags/8.6-rc1.tar.gz
 ARG REDIS_DOWNLOAD_SHA=dc387a093cb4f956953492eeb613e833b53ee23a45625bde01cc6d2497a5c0e7
 

--- a/debian/Dockerfile.j2
+++ b/debian/Dockerfile.j2
@@ -14,6 +14,9 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
+{% if release_tag %}
+ENV REDIS_VERSION={{ release_tag }}
+{% endif %}
 ARG REDIS_DOWNLOAD_URL={{ redis_download_url | required("redis_download_url is required") }}
 {% if not custom_build %}
 ARG REDIS_DOWNLOAD_SHA={{ redis_download_sha | required("redis_download_sha is required") }}

--- a/release-automation/src/stackbrew_generator/dockerfile.py
+++ b/release-automation/src/stackbrew_generator/dockerfile.py
@@ -15,6 +15,7 @@ class DockerfileContext(BaseModel):
         redis_download_url: Redis source tarball download URL (required)
         redis_download_sha: Redis source tarball SHA256 checksum (required)
     """
+    release_tag: str = ""
     custom_build: bool = False
     redis_download_url: str = ""
     redis_download_sha: str = ""


### PR DESCRIPTION
Related to https://github.com/redis/docker-library-redis/issues/518 (but for newer versions)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: build metadata/templating changes that only add a new env var and JSON field, with minimal impact on runtime behavior.
> 
> **Overview**
> Adds `release_tag` to `.redis.version.json` and updates the version-apply GitHub Action script to write it when bumping Redis.
> 
> Updates the Alpine and Debian Dockerfile Jinja templates (and regenerated Dockerfiles) to set `ENV REDIS_VERSION={{ release_tag }}` when provided, and extends the stackbrew Dockerfile rendering context to accept `release_tag`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b4bfa31338cdb040a7fea72250953e172489a7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->