### PR TITLE
Remove backports target release

### DIFF
--- a/.github/actions/apply-docker-version/apply-docker-version.sh
+++ b/.github/actions/apply-docker-version/apply-docker-version.sh
@@ -4,7 +4,7 @@ set -e
 # This script updates .redis.version.json and regenerates Dockerfiles from templates
 # using environment variables REDIS_ARCHIVE_URL and REDIS_ARCHIVE_SHA.
 
-# Input TAG is expected in $1
+# Input TAG is expected in first argument
 TAG="$1"
 
 if [ -z "$TAG" ]; then

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -54,7 +54,7 @@ RUN set -eux; \
 			autoconf \
 			libtool \
 			g++; \
-		apt-get install -y --no-install-recommends -t trixie-backports clang-21 lld-21 llvm-21; \
+		apt-get install -y --no-install-recommends clang-21 lld-21 llvm-21; \
 		export PATH="/usr/lib/llvm-21/bin:$PATH"; \
 	fi; \
 	\

--- a/debian/Dockerfile.j2
+++ b/debian/Dockerfile.j2
@@ -64,7 +64,7 @@ RUN set -eux; \
 			autoconf \
 			libtool \
 			g++; \
-		apt-get install -y --no-install-recommends -t trixie-backports clang-21 lld-21 llvm-21; \
+		apt-get install -y --no-install-recommends clang-21 lld-21 llvm-21; \
 		export PATH="/usr/lib/llvm-21/bin:$PATH"; \
 	fi; \
 	\


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts Debian image build dependencies by no longer pinning `clang-21`/`lld-21`/`llvm-21` to `trixie-backports`, which could break builds if those versions aren’t available in the default apt sources. Otherwise changes are small and localized to Docker build tooling.
> 
> **Overview**
> Removes the `-t trixie-backports` target release when installing `clang-21`/`lld-21`/`llvm-21` in the Debian Docker build, both in `debian/Dockerfile` and the `debian/Dockerfile.j2` template.
> 
> Also tweaks the `apply-docker-version.sh` comment to clarify that the TAG comes from the first positional argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 759c1a2231cd7fd02bf33898a5fa8fbbc204c603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->