### PR TITLE
This allows nightly as run_type parameter

### DIFF
--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -15,7 +15,7 @@ on:
         description: 'Release type: either public or internal'
         required: true
       run_type:
-        description: 'Run type, either release, unstable or custom'
+        description: 'Run type, either release, unstable, custom or nightly'
         required: true
         default: "custom"
       workflow_uuid:
@@ -82,7 +82,7 @@ jobs:
             exit 1
           fi
 
-          if ! [[ "$INPUTS_RUN_TYPE" =~ ^(release|unstable|custom)$ ]]; then
+          if ! [[ "$INPUTS_RUN_TYPE" =~ ^(release|unstable|custom|nightly)$ ]]; then
             echo "::error::Invalid run type: $INPUTS_RUN_TYPE"
             exit 1
           fi


### PR DESCRIPTION
It is already supported by all downstream workflows and actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only expands allowed `workflow_dispatch` input validation for `run_type` in a GitHub Actions workflow, without changing build/release logic.
> 
> **Overview**
> Updates `release_build_and_test.yml` to accept `nightly` as a valid `run_type` for `workflow_dispatch` runs.
> 
> This changes the input description and extends the bash regex validation so `nightly` no longer fails input checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15cd7e1eb1f7873f3e6e4bd4b0c77b780678703. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->