### PR TITLE
Allow Redis buildsystem to recognize and link against libsystemd

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -30,6 +30,8 @@ RUN set -eux; \
 		g++ \
 		libc6-dev \
 		libssl-dev \
+		libsystemd-dev \
+		pkg-config \
 		make; \
 	\
 	arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \

--- a/debian/Dockerfile.j2
+++ b/debian/Dockerfile.j2
@@ -40,6 +40,8 @@ RUN set -eux; \
 		g++ \
 		libc6-dev \
 		libssl-dev \
+		libsystemd-dev \
+		pkg-config \
 		make; \
 	\
 	arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \

--- a/test/run-entrypoint-tests.sh
+++ b/test/run-entrypoint-tests.sh
@@ -705,5 +705,19 @@ test_redis_server_modules_are_loaded() {
 	run_redis_docker_and_check_modules /usr/local/bin/redis-server
 }
 
+# If the base image ships libsystemd, redis-server must be built against it so
+# that it can talk to systemd (sd_notify). On images without libsystemd (e.g.
+# Alpine) the binary is built without systemd support, so the test is skipped.
+test_redis_server_is_linked_against_libsystemd() {
+	if ! docker run --rm --entrypoint sh "$REDIS_IMG" -c 'find /lib /usr/lib -name "libsystemd.so*" 2>/dev/null | grep -q .'; then
+		echo "Skipping: libsystemd is not present in the base image"
+		startSkipping
+		return 0
+	fi
+
+	linked=$(docker run --rm --entrypoint sh "$REDIS_IMG" -c 'ldd "$(command -v redis-server)"')
+	assertContains "redis-server should be linked against libsystemd" "$linked" "libsystemd.so"
+}
+
 # shellcheck disable=SC1091
 . ./shunit2


### PR DESCRIPTION
libsystemd0 already exists in trixie base image
linking agaings libsystemd.so end enabling systemd support in Redis doesn't change its behaviour when systemd socket is not available

This allows Redis buildsystem to enable BUILD_WITH_SYSTEMD automatically by detecting according package.
Simple test is added to ensure redis is linked to libsystemd.so if it exists in the base image

For #373

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time dependency and regression-test changes only; no runtime behavior change when systemd sockets are absent.
> 
> **Overview**
> Debian image builds now install **`libsystemd-dev`** and **`pkg-config`** during compile so Redis can auto-enable systemd integration (e.g. **`sd_notify`**) when the upstream build detects the library. The same dependency list is mirrored in **`debian/Dockerfile.j2`**.
> 
> A new entrypoint test **`test_redis_server_is_linked_against_libsystemd`** runs only when the runtime image actually ships **`libsystemd.so`**; it uses **`ldd`** on **`redis-server`** and skips on bases like Alpine that do not include systemd.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a38dcaa185c30651c0eb2f8fb324daf212c7bbb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->