### PR TITLE
RED-198334 Bump GH Actions off Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     outputs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker-library/bashbrew@HEAD
+      - uses: actions/checkout@v6
+      - uses: docker-library/bashbrew@v0.1.14
       - id: generate-jobs
         name: Generate Jobs
         run: |
@@ -33,7 +33,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}
       - name: Pull Dependencies

--- a/.github/workflows/verify-templating.yml
+++ b/.github/workflows/verify-templating.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check For Uncomitted Changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Apply Templates
         run: ./apply-templates.sh
       - name: Check Git Status


### PR DESCRIPTION
## Summary
RED-198334. Bump GitHub Actions still running on Node 20 ahead of the June 16, 2026 deprecation deadline.

- Bump `actions/checkout@v3` -> `@v6` (3 sites in `ci.yml`, `verify-templating.yml`)
- Pin `docker-library/bashbrew@HEAD` -> `@v0.1.14` (latest tagged release; avoids floating HEAD pin)

## Test plan
- [ ] CI workflow runs cleanly on this PR
- [ ] Verify-templating workflow runs cleanly
- [ ] `generate-jobs` step still produces a valid strategy with the pinned bashbrew version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency version bumps with no application or runtime code changes; main risk is CI breakage if the new action or bashbrew pin behaves differently.
> 
> **Overview**
> Updates GitHub Actions in **CI** and **verify-templating** so jobs no longer rely on Node 20–era action versions ahead of the June 2026 deprecation.
> 
> **`actions/checkout`** is bumped from **v3** to **v6** in all three checkout steps (`generate-jobs` and `test` in `ci.yml`, plus `apply-templates` in `verify-templating.yml`). In **`ci.yml`**, **`docker-library/bashbrew`** is pinned from floating **`@HEAD`** to **`@v0.1.14`** so the generate-jobs matrix step uses a fixed release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 848c488f678a5d0ed0df586508348c8bbf1782ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->