### PR TITLE
RED-198334 Bump GH Actions off Node 20 (release/8.2)

### DIFF
--- a/.github/actions/apply-docker-version/action.yml
+++ b/.github/actions/apply-docker-version/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout common functions
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: redis-developer/redis-oss-release-automation
         ref: main
@@ -35,7 +35,7 @@ runs:
 
     - name: Create verified commit
       if: steps.apply-version.outputs.changed_files != ''
-      uses: iarekylew00t/verified-bot-commit@v1
+      uses: iarekylew00t/verified-bot-commit@v2
       with:
         message: ${{ inputs.release_tag }}
         files: ${{ steps.apply-version.outputs.changed_files }}

--- a/.github/actions/build-and-tag-locally/action.yml
+++ b/.github/actions/build-and-tag-locally/action.yml
@@ -48,7 +48,7 @@ runs:
         sudo apt-get update
         sudo apt-get install -y qemu-user-static
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Calculate architecture name
       id: platform
@@ -96,7 +96,7 @@ runs:
         docker rmi -f ${{ github.sha }}:${{ steps.platform.outputs.display_name }} || true
 
     - name: Docker Login
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       if: inputs.publish_image == 'true'
       with:
         registry: ${{ inputs.registry_repository }}
@@ -185,7 +185,7 @@ runs:
 
     - name: Build
       id: build
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.distribution }}
         push: false
@@ -244,7 +244,7 @@ runs:
 
     - name: Upload build failure logs
       if: failure() && steps.build.outcome == 'failure' && inputs.run_type == 'nightly'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build-failure-${{ steps.platform.outputs.display_name }}-${{ inputs.distribution }}
         path: /tmp/build-logs/
@@ -372,7 +372,7 @@ runs:
         -- --output-junit-xml=report-entrypoint.xml
 
     - name: Test Report
-      uses: dorny/test-reporter@v2
+      uses: dorny/test-reporter@v3
       # run this step even if previous step failed, but not if it was skipped
       if: ${{ !cancelled() && steps.test_entrypoint.conclusion != 'skipped' }}
       with:
@@ -417,7 +417,7 @@ runs:
           redistimeseries_version: ${{ inputs.redistimeseries_version }}
 
     - name: Push image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       if: ${{ inputs.publish_image == 'true' && contains(fromJSON('["amd64", "arm64"]'), steps.platform.outputs.display_name) }}
       with:
         context: ${{ inputs.distribution }}
@@ -457,7 +457,7 @@ runs:
         fi
 
     - name: Upload image metadata artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ inputs.publish_image == 'true' && contains(fromJSON('["amd64", "arm64"]'), steps.platform.outputs.display_name) }}
       with:
         name: image-metadata-${{ inputs.distribution }}-${{ steps.platform.outputs.display_name }}

--- a/.github/actions/create-image-labels/action.yml
+++ b/.github/actions/create-image-labels/action.yml
@@ -31,7 +31,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Redis repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: redis/redis
         path: redis
@@ -61,7 +61,7 @@ runs:
 
     - name: Checkout Redisearch repository
       if: inputs.modules_enabled == 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: RediSearch/RediSearch
         path: redisearch
@@ -69,7 +69,7 @@ runs:
 
     - name: Checkout Redisjson repository
       if: inputs.modules_enabled == 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: redisjson/redisjson
         path: redisjson
@@ -77,7 +77,7 @@ runs:
 
     - name: Checkout RedisTimeSeries repository
       if: inputs.modules_enabled == 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: RedisTimeSeries/RedisTimeSeries
         path: redistimeseries
@@ -85,7 +85,7 @@ runs:
 
     - name: Checkout RedisBloom repository
       if: inputs.modules_enabled == 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: RedisBloom/RedisBloom
         path: redisbloom

--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout common functions
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: redis-developer/redis-oss-release-automation
         ref: main

--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -64,7 +64,7 @@ jobs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: >-
             ${{ (github.ref_name == 'unstable'
@@ -99,7 +99,7 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-build-matrix.outputs.matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: >-
             ${{ (github.ref_name == 'unstable'
@@ -141,10 +141,10 @@ jobs:
           - alpine
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -212,7 +212,7 @@ jobs:
           EOF
 
       - name: Upload image metadata artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: image-metadata-${{ matrix.distribution }}-multi-arch
           path: /tmp/image-metadata/${{ matrix.distribution }}-multi-arch.json
@@ -226,7 +226,7 @@ jobs:
       docker_images_metadata: ${{ steps.collect-metadata.outputs.metadata }}
     steps:
       - name: Download all images metadata artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: image-metadata-*
           path: ./images-metadata
@@ -256,7 +256,7 @@ jobs:
       slack_url: ${{ steps.slack-success.outputs.slack_url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Send Slack notification
         id: slack-success
@@ -279,7 +279,7 @@ jobs:
       slack_url: ${{ steps.slack-failure.outputs.slack_url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Send Failure Slack notification
         id: slack-failure

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Validate Dockerfiles are synced with templates
         uses: ./.github/actions/validate-dockerfiles-synced
 

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -65,7 +65,7 @@ jobs:
       slack_fanout_msg_links: ${{ steps.slack-routing.outputs.slack_fanout_msg_links }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install release automation dependencies
         uses: ./.github/actions/release-automation-install
@@ -124,7 +124,7 @@ jobs:
           fi
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -179,7 +179,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Ensure Release Branch
         if: github.event.inputs.run_type == 'release'
@@ -258,7 +258,7 @@ jobs:
           cat result.json | jq '.'
 
       - name: Upload release handle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_handle
           path: result.json
@@ -275,7 +275,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Post announcement link to Slack
       uses: ./.github/actions/slack-notification

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Parse release handle and validate
         id: parse-release
@@ -124,7 +124,7 @@ jobs:
           fi
 
       - name: Checkout official-images repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: official-images
           repository: ${{ github.event.inputs.pr_to_official_library == 'true' && env.TARGET_OFFICIAL_IMAGES_REPO || env.FORKED_OFFICIAL_IMAGES_REPO }}
@@ -133,10 +133,10 @@ jobs:
         uses: ./.github/actions/release-automation-install
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -189,7 +189,7 @@ jobs:
 
       - name: Create pull request to official-images
         id: create-pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_TOKEN_FOR_PR_2 }}
           draft: true
@@ -271,7 +271,7 @@ jobs:
           cat result.json | jq '.'
 
       - name: Upload release info artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_info
           path: result.json


### PR DESCRIPTION
## Summary
RED-198334. Cherry-pick of the canonical Node 20 -> Node 24 bump from `unstable` ([#526](https://github.com/redis/docker-library-redis/pull/526)). Targets `release/8.2`.

- Bump first-party actions: `actions/checkout@v4` -> `@v6` (16 sites), `actions/upload-artifact@v4` -> `@v7` (5 sites), `actions/download-artifact@v4` -> `@v7`
- Bump `docker/*` actions: `setup-buildx` v3->v4 (3 sites), `login` v3->v4 (4 sites), `build-push` v6->v7 (2 sites)
- Bump `dorny/test-reporter` v2->v3, `peter-evans/create-pull-request` v7->v8, `iarekylew00t/verified-bot-commit` v1->v2

## Test plan
- [ ] `pull-request.yml` runs cleanly on this PR
- [ ] On next release tag, `release_build_and_test.yml` produces same image digests with bumped actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes to workflow YAML with no Redis image or application code touched; main risk is CI/regression if a bumped action has breaking behavior, which PR and release test plans are meant to catch.
> 
> **Overview**
> **Cherry-pick (RED-198334)** onto `release/8.2` to move CI off deprecated Node 20 runners by bumping third-party GitHub Action pins only—no workflow logic or build scripts change.
> 
> **First-party:** `actions/checkout` **v4 → v6** across composite actions and workflows; `actions/upload-artifact` **v4 → v7** and `actions/download-artifact` **v4 → v7** for metadata, release handles, and failure logs.
> 
> **Docker tooling:** `docker/setup-buildx-action` **v3 → v4**, `docker/login-action` **v3 → v4**, and `docker/build-push-action` **v6 → v7** in local build/push and multi-arch jobs.
> 
> **Other:** `dorny/test-reporter` **v2 → v3**, `peter-evans/create-pull-request` **v7 → v8**, `iarekylew00t/verified-bot-commit` **v1 → v2** for release commits and official-images PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84039dd67b678d150cc4ee6765c588f2ff2b9112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->