### PR TITLE
Unstable adapt Dockerfiles and workflows to redis modules modernization

### DIFF
--- a/.github/actions/build-and-tag-locally/action.yml
+++ b/.github/actions/build-and-tag-locally/action.yml
@@ -420,6 +420,7 @@ runs:
       uses: ./.github/actions/create-image-labels
       with:
           redis_version: ${{ inputs.release_tag }}
+          redis_repo: ${{ inputs.redis_repo }}
           modules_enabled: ${{ steps.redis-version.outputs.modules_enabled }}
           redisearch_version: ${{ inputs.redisearch_version }}
           redisjson_version: ${{ inputs.redisjson_version }}

--- a/.github/actions/build-and-tag-locally/action.yml
+++ b/.github/actions/build-and-tag-locally/action.yml
@@ -23,6 +23,10 @@ inputs:
   release_tag:
     description: 'Release tag to build'
     required: false
+  redis_repo:
+    description: 'GitHub owner/repo to pull Redis sources from (allows using a fork)'
+    default: 'redis/redis'
+    required: false
   redisearch_version:
     description: 'Redisearch version to build'
     required: false
@@ -108,16 +112,18 @@ runs:
       if: inputs.run_type != 'release' && inputs.run_type != 'pr'
       env:
         TAG: ${{ inputs.release_tag }}
+        REDIS_REPO: ${{ inputs.redis_repo }}
       run: |
         # Figure out the correct URL for the Redis release archive.
+        # REDIS_REPO defaults to redis/redis but may point at a fork.
         # Prefer a bundled redis-full.tar.gz release asset (Redis core + modules) when
         # published for this tag; otherwise fall back to the plain source archive.
         REDIS_DOWNLOAD_URL=""
         for URL in \
-          "https://github.com/redis/redis/releases/download/$TAG/redis-full.tar.gz" \
-          "https://github.com/redis/redis/archive/refs/tags/$TAG.tar.gz" \
-          "https://github.com/redis/redis/archive/refs/heads/$TAG.tar.gz" \
-          "https://github.com/redis/redis/archive/$TAG.tar.gz"; do
+          "https://github.com/$REDIS_REPO/releases/download/$TAG/redis-full.tar.gz" \
+          "https://github.com/$REDIS_REPO/archive/refs/tags/$TAG.tar.gz" \
+          "https://github.com/$REDIS_REPO/archive/refs/heads/$TAG.tar.gz" \
+          "https://github.com/$REDIS_REPO/archive/$TAG.tar.gz"; do
           if curl --fail -sS -IL -w "%{http_code} %{url}\n" "$URL" -o /dev/null; then
             REDIS_DOWNLOAD_URL=$URL
             echo "REDIS_DOWNLOAD_URL=$URL" | tee -a "$GITHUB_ENV"

--- a/.github/actions/build-and-tag-locally/action.yml
+++ b/.github/actions/build-and-tag-locally/action.yml
@@ -109,9 +109,12 @@ runs:
       env:
         TAG: ${{ inputs.release_tag }}
       run: |
-        # Figure out the correct URL for the Redis release archive
+        # Figure out the correct URL for the Redis release archive.
+        # Prefer a bundled redis-full.tar.gz release asset (Redis core + modules) when
+        # published for this tag; otherwise fall back to the plain source archive.
         REDIS_DOWNLOAD_URL=""
         for URL in \
+          "https://github.com/redis/redis/releases/download/$TAG/redis-full.tar.gz" \
           "https://github.com/redis/redis/archive/refs/tags/$TAG.tar.gz" \
           "https://github.com/redis/redis/archive/refs/heads/$TAG.tar.gz" \
           "https://github.com/redis/redis/archive/$TAG.tar.gz"; do

--- a/.github/actions/build-and-tag-locally/action.yml
+++ b/.github/actions/build-and-tag-locally/action.yml
@@ -154,7 +154,8 @@ runs:
         trap 'rm -rf "$tmpdir"' EXIT
 
         curl --fail -Ls "$REDIS_DOWNLOAD_URL" -o "$tmpdir/redis.tar.gz"
-        version_h_path=$(tar -tzf "$tmpdir/redis.tar.gz" | grep '/src/version.h$' | head -n1)
+        # core version.h is <topdir>/src/version.h; anchor so redis-full module version.h don't match
+        version_h_path=$(tar -tzf "$tmpdir/redis.tar.gz" | grep -E '^[^/]+/src/version.h$' | head -n1)
 
         if [ -z "$version_h_path" ]; then
           echo "Failed to locate src/version.h in Redis archive"

--- a/.github/actions/create-image-labels/action.yml
+++ b/.github/actions/create-image-labels/action.yml
@@ -45,22 +45,23 @@ runs:
       if: inputs.modules_enabled == 'true' && (inputs.redisearch_version == '' || inputs.redisjson_version == '' || inputs.redistimeseries_version == '' || inputs.redisbloom_version == '')
       shell: bash
       run: |
-        get_module_version() {
-          local module="$1"
-          grep MODULE_VERSION modules/$module/Makefile | cut -d '=' -f2 | tr -d ' '
-        }
+        # read each module's pinned ref from modules.yaml (manifest is the single
+        # source of truth; the per-module MODULE_VERSION Makefiles were removed)
         cd redis
+        get_module_ref() {
+          sh scripts/lib/manifest.sh ref "$1"
+        }
         if [ -z "${{ inputs.redisearch_version }}" ]; then
-          echo redisearch_version=$(get_module_version redisearch) >> $GITHUB_ENV
+          echo redisearch_version=$(get_module_ref redisearch) >> $GITHUB_ENV
         fi
         if [ -z "${{ inputs.redisjson_version }}" ]; then
-          echo redisjson_version=$(get_module_version redisjson) >> $GITHUB_ENV
+          echo redisjson_version=$(get_module_ref redisjson) >> $GITHUB_ENV
         fi
         if [ -z "${{ inputs.redisbloom_version }}" ]; then
-          echo redisbloom_version=$(get_module_version redisbloom) >> $GITHUB_ENV
+          echo redisbloom_version=$(get_module_ref redisbloom) >> $GITHUB_ENV
         fi
         if [ -z "${{ inputs.redistimeseries_version }}" ]; then
-          echo redistimeseries_version=$(get_module_version redistimeseries) >> $GITHUB_ENV
+          echo redistimeseries_version=$(get_module_ref redistimeseries) >> $GITHUB_ENV
         fi
 
     - name: Checkout Redisearch repository

--- a/.github/actions/create-image-labels/action.yml
+++ b/.github/actions/create-image-labels/action.yml
@@ -5,6 +5,10 @@ inputs:
   redis_version:
     description: 'Redis version to build'
     required: true
+  redis_repo:
+    description: 'GitHub owner/repo to pull Redis sources from (allows using a fork)'
+    required: false
+    default: 'redis/redis'
   modules_enabled:
     description: 'Whether module-related labels should be included'
     required: false
@@ -33,7 +37,7 @@ runs:
     - name: Checkout Redis repository
       uses: actions/checkout@v6
       with:
-        repository: redis/redis
+        repository: ${{ inputs.redis_repo }}
         path: redis
         ref: ${{ inputs.redis_version }}
 
@@ -117,7 +121,7 @@ runs:
         else
           labels+="io.redis.version=$VER"$'\n'
         fi
-        labels+="io.redis.source=https://github.com/redis/redis"$'\n'
+        labels+="io.redis.source=https://github.com/${{ inputs.redis_repo }}"$'\n'
         echo "labels: $labels"
         echo "image_labels<<EOF" >> $GITHUB_OUTPUT
         echo "$labels" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -7,6 +7,11 @@ on:
         description: 'Release tag to build'
         required: true
         type: string
+      redis_repo:
+        description: 'GitHub owner/repo to pull Redis sources from (allows using a fork)'
+        required: false
+        type: string
+        default: 'redis/redis'
       redisearch_version:
         description: 'Redisearch version to build'
         required: false
@@ -124,6 +129,7 @@ jobs:
           publish_image: ${{ inputs.publish_image }}
           registry_repository: ${{ format('ghcr.io/{0}', github.repository) }}
           release_tag: ${{ inputs.release_tag }}
+          redis_repo: ${{ inputs.redis_repo }}
           redisearch_version: ${{ inputs.redisearch_version }}
           redisjson_version: ${{ inputs.redisjson_version }}
           redisbloom_version: ${{ inputs.redisbloom_version }}

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -11,6 +11,10 @@ on:
       release_tag:
         description: 'Release tag to build'
         required: true
+      redis_repo:
+        description: 'GitHub owner/repo to pull Redis sources from (allows using a fork)'
+        required: false
+        default: 'redis/redis'
       release_type:
         description: 'Release type: either public or internal'
         required: true
@@ -164,6 +168,7 @@ jobs:
     secrets: inherit
     with:
       release_tag: ${{ github.event.inputs.release_tag }}
+      redis_repo: ${{ github.event.inputs.redis_repo }}
       publish_image: true
       redisearch_version: ${{ github.event.inputs.redisearch_version }}
       redisjson_version: ${{ github.event.inputs.redisjson_version }}

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -112,12 +112,14 @@ RUN set -eux; \
 	export BUILD_TLS=yes; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 		export LTO=1; \
-# bundled redis-full ships module sources (.prepared); otherwise clone pinned refs (shallow)
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1; then \
+# bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1 && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]; then \
 			echo "Using bundled module sources (redis-full); skipping modules-update"; \
 		else \
 			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
 		fi; \
+# make deploy/build.sh bypass modules/Makefile, so install the pinned Rust toolchain here
+		make -C /usr/src/redis/modules install-rust INSTALL_RUST_TOOLCHAIN=yes; \
 		make -C /usr/src/redis -j "$(nproc)" deploy; \
 	else \
 		make -C /usr/src/redis -j "$(nproc)" deploy redis; \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -31,9 +31,8 @@ RUN set -eux; \
 	\
 	arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
 	case "$arch" in \
-		'amd64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes ;; \
-		'arm64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes ;; \
-		*) echo >&2 "Modules are NOT supported! unsupported architecture: '$arch'"; export BUILD_WITH_MODULES=no ;; \
+		'amd64' | 'arm64') BUILD_WITH_MODULES=yes ;; \
+		*) echo >&2 "Modules are NOT supported! unsupported architecture: '$arch'"; BUILD_WITH_MODULES=no ;; \
 	esac; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 	apk add --no-cache --virtual .module-build-deps \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -51,6 +51,7 @@ RUN set -eux; \
 		g++ \
 		git \
 		libffi-dev \
+		yq \
 		libgcc \
 		libtool \
 		llvm21-dev \
@@ -111,13 +112,16 @@ RUN set -eux; \
 	export BUILD_TLS=yes; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 		export LTO=1; \
-		make -C /usr/src/redis/modules/redisjson get_source; \
-		sed -i 's/^RUST_FLAGS=$/RUST_FLAGS += -C target-feature=-crt-static/' /usr/src/redis/modules/redisjson/src/Makefile ; \
-		grep -E 'RUST_FLAGS' /usr/src/redis/modules/redisjson/src/Makefile; \
+# bundled redis-full ships module sources (.prepared); otherwise clone pinned refs (shallow)
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1; then \
+			echo "Using bundled module sources (redis-full); skipping modules-update"; \
+		else \
+			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
+		fi; \
+		make -C /usr/src/redis -j "$(nproc)" deploy; \
+	else \
+		make -C /usr/src/redis -j "$(nproc)" deploy redis; \
 	fi; \
-	make -C /usr/src/redis -j "$(nproc)" all; \
-	make -C /usr/src/redis install; \
-	make -C /usr/src/redis distclean; \
 	rm -r /usr/src/redis; \
 	\
 	runDeps="$( \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -112,7 +112,7 @@ RUN set -eux; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 		export LTO=1; \
 # bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1 && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]; then \
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1; then \
 			echo "Using bundled module sources (redis-full); skipping modules-update"; \
 		else \
 			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -51,7 +51,7 @@ RUN set -eux; \
 		g++ \
 		git \
 		libffi-dev \
-		yq \
+		yq-go \
 		libgcc \
 		libtool \
 		llvm21-dev \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -120,6 +120,8 @@ RUN set -eux; \
 # make deploy/build.sh bypass modules/Makefile, so install the pinned Rust toolchain here
 		make -C /usr/src/redis/modules install-rust INSTALL_RUST_TOOLCHAIN=yes; \
 		make -C /usr/src/redis -j "$(nproc)" deploy; \
+# remove the toolchain from /usr/local so it neither bloats the image nor pollutes runtime-dep detection
+		make -C /usr/src/redis/modules uninstall-rust INSTALL_RUST_TOOLCHAIN=yes; \
 	else \
 		make -C /usr/src/redis -j "$(nproc)" deploy redis; \
 	fi; \

--- a/alpine/Dockerfile.j2
+++ b/alpine/Dockerfile.j2
@@ -146,6 +146,8 @@ RUN set -eux; \
 # make deploy/build.sh bypass modules/Makefile, so install the pinned Rust toolchain here
 		make -C /usr/src/redis/modules install-rust INSTALL_RUST_TOOLCHAIN=yes; \
 		make -C /usr/src/redis -j "$(nproc)" deploy; \
+# remove the toolchain from /usr/local so it neither bloats the image nor pollutes runtime-dep detection
+		make -C /usr/src/redis/modules uninstall-rust INSTALL_RUST_TOOLCHAIN=yes; \
 	else \
 		make -C /usr/src/redis -j "$(nproc)" deploy redis; \
 	fi; \

--- a/alpine/Dockerfile.j2
+++ b/alpine/Dockerfile.j2
@@ -62,7 +62,7 @@ RUN set -eux; \
 		g++ \
 		git \
 		libffi-dev \
-		yq \
+		yq-go \
 		libgcc \
 		libtool \
 		llvm21-dev \

--- a/alpine/Dockerfile.j2
+++ b/alpine/Dockerfile.j2
@@ -62,6 +62,7 @@ RUN set -eux; \
 		g++ \
 		git \
 		libffi-dev \
+		yq \
 		libgcc \
 		libtool \
 		llvm21-dev \
@@ -128,32 +129,25 @@ RUN set -eux; \
 	export BUILD_TLS=yes; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 		export LTO=1; \
-
-	{%- if custom_build %}
-
-		# Update modules versions
-		if [ -n "$REDISEARCH_VERSION" ]; then \
-			sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISEARCH_VERSION" /usr/src/redis/modules/redisearch/Makefile; \
+	{% if custom_build %}
+# pin module refs in modules.yaml from build-args (empty args leave the pin untouched)
+		if [ -f /usr/src/redis/modules/modules.yaml ]; then \
+			[ -z "$REDISEARCH_VERSION" ] || yq -i '(.modules[] | select(.name == "redisearch").ref) = strenv(REDISEARCH_VERSION)' /usr/src/redis/modules/modules.yaml; \
+			[ -z "$REDISJSON_VERSION" ] || yq -i '(.modules[] | select(.name == "redisjson").ref) = strenv(REDISJSON_VERSION)' /usr/src/redis/modules/modules.yaml; \
+			[ -z "$REDISBLOOM_VERSION" ] || yq -i '(.modules[] | select(.name == "redisbloom").ref) = strenv(REDISBLOOM_VERSION)' /usr/src/redis/modules/modules.yaml; \
+			[ -z "$REDISTIMESERIES_VERSION" ] || yq -i '(.modules[] | select(.name == "redistimeseries").ref) = strenv(REDISTIMESERIES_VERSION)' /usr/src/redis/modules/modules.yaml; \
 		fi; \
-		if [ -n "$REDISJSON_VERSION" ]; then \
-			sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISJSON_VERSION" /usr/src/redis/modules/redisjson/Makefile; \
+	{% endif %}
+# bundled redis-full ships module sources (.prepared); otherwise clone pinned refs (shallow)
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1; then \
+			echo "Using bundled module sources (redis-full); skipping modules-update"; \
+		else \
+			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
 		fi; \
-		if [ -n "$REDISBLOOM_VERSION" ]; then \
-			sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISBLOOM_VERSION" /usr/src/redis/modules/redisbloom/Makefile; \
-		fi; \
-		if [ -n "$REDISTIMESERIES_VERSION" ]; then \
-			sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISTIMESERIES_VERSION" /usr/src/redis/modules/redistimeseries/Makefile; \
-		fi; \
-
-	{%- endif %}
-
-		make -C /usr/src/redis/modules/redisjson get_source; \
-		sed -i 's/^RUST_FLAGS=$/RUST_FLAGS += -C target-feature=-crt-static/' /usr/src/redis/modules/redisjson/src/Makefile ; \
-		grep -E 'RUST_FLAGS' /usr/src/redis/modules/redisjson/src/Makefile; \
+		make -C /usr/src/redis -j "$(nproc)" deploy; \
+	else \
+		make -C /usr/src/redis -j "$(nproc)" deploy redis; \
 	fi; \
-	make -C /usr/src/redis -j "$(nproc)" all; \
-	make -C /usr/src/redis install; \
-	make -C /usr/src/redis distclean; \
 	rm -r /usr/src/redis; \
 	\
 	runDeps="$( \

--- a/alpine/Dockerfile.j2
+++ b/alpine/Dockerfile.j2
@@ -138,12 +138,14 @@ RUN set -eux; \
 			[ -z "$REDISTIMESERIES_VERSION" ] || yq -i '(.modules[] | select(.name == "redistimeseries").ref) = strenv(REDISTIMESERIES_VERSION)' /usr/src/redis/modules/modules.yaml; \
 		fi; \
 	{% endif %}
-# bundled redis-full ships module sources (.prepared); otherwise clone pinned refs (shallow)
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1; then \
+# bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1 && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]; then \
 			echo "Using bundled module sources (redis-full); skipping modules-update"; \
 		else \
 			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
 		fi; \
+# make deploy/build.sh bypass modules/Makefile, so install the pinned Rust toolchain here
+		make -C /usr/src/redis/modules install-rust INSTALL_RUST_TOOLCHAIN=yes; \
 		make -C /usr/src/redis -j "$(nproc)" deploy; \
 	else \
 		make -C /usr/src/redis -j "$(nproc)" deploy redis; \

--- a/alpine/Dockerfile.j2
+++ b/alpine/Dockerfile.j2
@@ -42,9 +42,8 @@ RUN set -eux; \
 	\
 	arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
 	case "$arch" in \
-		'amd64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes ;; \
-		'arm64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes ;; \
-		*) echo >&2 "Modules are NOT supported! unsupported architecture: '$arch'"; export BUILD_WITH_MODULES=no ;; \
+		'amd64' | 'arm64') BUILD_WITH_MODULES=yes ;; \
+		*) echo >&2 "Modules are NOT supported! unsupported architecture: '$arch'"; BUILD_WITH_MODULES=no ;; \
 	esac; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 	apk add --no-cache --virtual .module-build-deps \

--- a/alpine/Dockerfile.j2
+++ b/alpine/Dockerfile.j2
@@ -138,7 +138,7 @@ RUN set -eux; \
 		fi; \
 	{% endif %}
 # bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1 && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]; then \
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1{% if custom_build %} && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]{% endif %}; then \
 			echo "Using bundled module sources (redis-full); skipping modules-update"; \
 		else \
 			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -36,9 +36,8 @@ RUN set -eux; \
 	\
 	arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
 	case "$arch" in \
-		'amd64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes ;; \
-		'arm64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes ;; \
-		*) echo >&2 "Modules are NOT supported! unsupported architecture: '$arch'"; export BUILD_WITH_MODULES=no ;; \
+		'amd64' | 'arm64') BUILD_WITH_MODULES=yes ;; \
+		*) echo >&2 "Modules are NOT supported! unsupported architecture: '$arch'"; BUILD_WITH_MODULES=no ;; \
 	esac; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 		echo 'deb http://deb.debian.org/debian trixie-backports main' > /etc/apt/sources.list.d/backports.list; \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -45,6 +45,7 @@ RUN set -eux; \
 		apt-get update; \
 		apt-get install -y --no-install-recommends \
 			git \
+			yq \
 			cmake \
 			python3 \
 			python3-pip \
@@ -68,6 +69,7 @@ RUN set -eux; \
 	mkdir -p /usr/src/redis; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
+
 # disable Redis protected mode [1] as it is unnecessary in context of Docker
 # (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
 # [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
@@ -95,10 +97,16 @@ RUN set -eux; \
 	export BUILD_TLS=yes; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 		export LTO=1; \
+# bundled redis-full ships module sources (.prepared); otherwise clone pinned refs (shallow)
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1; then \
+			echo "Using bundled module sources (redis-full); skipping modules-update"; \
+		else \
+			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
+		fi; \
+		make -C /usr/src/redis -j "$(nproc)" deploy; \
+	else \
+		make -C /usr/src/redis -j "$(nproc)" deploy redis; \
 	fi; \
-	make -C /usr/src/redis -j "$(nproc)" all; \
-	make -C /usr/src/redis install; \
-	make -C /usr/src/redis distclean; \
 	rm -r /usr/src/redis; \
 	\
 	apt-mark auto '.*' > /dev/null; \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -97,12 +97,14 @@ RUN set -eux; \
 	export BUILD_TLS=yes; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 		export LTO=1; \
-# bundled redis-full ships module sources (.prepared); otherwise clone pinned refs (shallow)
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1; then \
+# bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1 && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]; then \
 			echo "Using bundled module sources (redis-full); skipping modules-update"; \
 		else \
 			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
 		fi; \
+# make deploy/build.sh bypass modules/Makefile, so install the pinned Rust toolchain here
+		make -C /usr/src/redis/modules install-rust INSTALL_RUST_TOOLCHAIN=yes; \
 		make -C /usr/src/redis -j "$(nproc)" deploy; \
 	else \
 		make -C /usr/src/redis -j "$(nproc)" deploy redis; \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -68,7 +68,6 @@ RUN set -eux; \
 	mkdir -p /usr/src/redis; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
-
 # disable Redis protected mode [1] as it is unnecessary in context of Docker
 # (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
 # [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
@@ -97,7 +96,7 @@ RUN set -eux; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 		export LTO=1; \
 # bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1 && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]; then \
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1; then \
 			echo "Using bundled module sources (redis-full); skipping modules-update"; \
 		else \
 			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -105,6 +105,8 @@ RUN set -eux; \
 # make deploy/build.sh bypass modules/Makefile, so install the pinned Rust toolchain here
 		make -C /usr/src/redis/modules install-rust INSTALL_RUST_TOOLCHAIN=yes; \
 		make -C /usr/src/redis -j "$(nproc)" deploy; \
+# remove the toolchain from /usr/local so it neither bloats the image nor pollutes runtime-dep detection
+		make -C /usr/src/redis/modules uninstall-rust INSTALL_RUST_TOOLCHAIN=yes; \
 	else \
 		make -C /usr/src/redis -j "$(nproc)" deploy redis; \
 	fi; \

--- a/debian/Dockerfile.j2
+++ b/debian/Dockerfile.j2
@@ -55,6 +55,7 @@ RUN set -eux; \
 		apt-get update; \
 		apt-get install -y --no-install-recommends \
 			git \
+			yq \
 			cmake \
 			python3 \
 			python3-pip \
@@ -85,25 +86,6 @@ RUN set -eux; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
 
-	{%- if custom_build %}
-
-	\
-	# Update modules versions
-	if [ -n "$REDISEARCH_VERSION" ]; then \
-		sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISEARCH_VERSION" /usr/src/redis/modules/redisearch/Makefile; \
-	fi; \
-	if [ -n "$REDISJSON_VERSION" ]; then \
-		sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISJSON_VERSION" /usr/src/redis/modules/redisjson/Makefile; \
-	fi; \
-	if [ -n "$REDISBLOOM_VERSION" ]; then \
-		sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISBLOOM_VERSION" /usr/src/redis/modules/redisbloom/Makefile; \
-	fi; \
-	if [ -n "$REDISTIMESERIES_VERSION" ]; then \
-		sed -i "/^MODULE_VERSION = /cMODULE_VERSION = $REDISTIMESERIES_VERSION" /usr/src/redis/modules/redistimeseries/Makefile; \
-	fi; \
-
-	{%- endif %}
-
 # disable Redis protected mode [1] as it is unnecessary in context of Docker
 # (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
 # [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
@@ -131,10 +113,25 @@ RUN set -eux; \
 	export BUILD_TLS=yes; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 		export LTO=1; \
+	{% if custom_build %}
+# pin module refs in modules.yaml from build-args (empty args leave the pin untouched)
+		if [ -f /usr/src/redis/modules/modules.yaml ]; then \
+			[ -z "$REDISEARCH_VERSION" ] || yq -y -i '(.modules[] | select(.name == "redisearch").ref) = env.REDISEARCH_VERSION' /usr/src/redis/modules/modules.yaml; \
+			[ -z "$REDISJSON_VERSION" ] || yq -y -i '(.modules[] | select(.name == "redisjson").ref) = env.REDISJSON_VERSION' /usr/src/redis/modules/modules.yaml; \
+			[ -z "$REDISBLOOM_VERSION" ] || yq -y -i '(.modules[] | select(.name == "redisbloom").ref) = env.REDISBLOOM_VERSION' /usr/src/redis/modules/modules.yaml; \
+			[ -z "$REDISTIMESERIES_VERSION" ] || yq -y -i '(.modules[] | select(.name == "redistimeseries").ref) = env.REDISTIMESERIES_VERSION' /usr/src/redis/modules/modules.yaml; \
+		fi; \
+	{% endif %}
+# bundled redis-full ships module sources (.prepared); otherwise clone pinned refs (shallow)
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1; then \
+			echo "Using bundled module sources (redis-full); skipping modules-update"; \
+		else \
+			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
+		fi; \
+		make -C /usr/src/redis -j "$(nproc)" deploy; \
+	else \
+		make -C /usr/src/redis -j "$(nproc)" deploy redis; \
 	fi; \
-	make -C /usr/src/redis -j "$(nproc)" all; \
-	make -C /usr/src/redis install; \
-	make -C /usr/src/redis distclean; \
 	rm -r /usr/src/redis; \
 	\
 	apt-mark auto '.*' > /dev/null; \

--- a/debian/Dockerfile.j2
+++ b/debian/Dockerfile.j2
@@ -46,9 +46,8 @@ RUN set -eux; \
 	\
 	arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
 	case "$arch" in \
-		'amd64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes ;; \
-		'arm64') export BUILD_WITH_MODULES=yes; export INSTALL_RUST_TOOLCHAIN=yes; export DISABLE_WERRORS=yes ;; \
-		*) echo >&2 "Modules are NOT supported! unsupported architecture: '$arch'"; export BUILD_WITH_MODULES=no ;; \
+		'amd64' | 'arm64') BUILD_WITH_MODULES=yes ;; \
+		*) echo >&2 "Modules are NOT supported! unsupported architecture: '$arch'"; BUILD_WITH_MODULES=no ;; \
 	esac; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 		echo 'deb http://deb.debian.org/debian trixie-backports main' > /etc/apt/sources.list.d/backports.list; \

--- a/debian/Dockerfile.j2
+++ b/debian/Dockerfile.j2
@@ -84,7 +84,6 @@ RUN set -eux; \
 	mkdir -p /usr/src/redis; \
 	tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1; \
 	rm redis.tar.gz; \
-
 # disable Redis protected mode [1] as it is unnecessary in context of Docker
 # (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
 # [1]: https://github.com/redis/redis/commit/edd4d555df57dc84265fdfb4ef59a4678832f6da
@@ -122,7 +121,7 @@ RUN set -eux; \
 		fi; \
 	{% endif %}
 # bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1 && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]; then \
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1{% if custom_build %} && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]{% endif %}; then \
 			echo "Using bundled module sources (redis-full); skipping modules-update"; \
 		else \
 			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \

--- a/debian/Dockerfile.j2
+++ b/debian/Dockerfile.j2
@@ -122,12 +122,14 @@ RUN set -eux; \
 			[ -z "$REDISTIMESERIES_VERSION" ] || yq -y -i '(.modules[] | select(.name == "redistimeseries").ref) = env.REDISTIMESERIES_VERSION' /usr/src/redis/modules/modules.yaml; \
 		fi; \
 	{% endif %}
-# bundled redis-full ships module sources (.prepared); otherwise clone pinned refs (shallow)
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1; then \
+# bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1 && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]; then \
 			echo "Using bundled module sources (redis-full); skipping modules-update"; \
 		else \
 			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
 		fi; \
+# make deploy/build.sh bypass modules/Makefile, so install the pinned Rust toolchain here
+		make -C /usr/src/redis/modules install-rust INSTALL_RUST_TOOLCHAIN=yes; \
 		make -C /usr/src/redis -j "$(nproc)" deploy; \
 	else \
 		make -C /usr/src/redis -j "$(nproc)" deploy redis; \

--- a/debian/Dockerfile.j2
+++ b/debian/Dockerfile.j2
@@ -130,6 +130,8 @@ RUN set -eux; \
 # make deploy/build.sh bypass modules/Makefile, so install the pinned Rust toolchain here
 		make -C /usr/src/redis/modules install-rust INSTALL_RUST_TOOLCHAIN=yes; \
 		make -C /usr/src/redis -j "$(nproc)" deploy; \
+# remove the toolchain from /usr/local so it neither bloats the image nor pollutes runtime-dep detection
+		make -C /usr/src/redis/modules uninstall-rust INSTALL_RUST_TOOLCHAIN=yes; \
 	else \
 		make -C /usr/src/redis -j "$(nproc)" deploy redis; \
 	fi; \


### PR DESCRIPTION
The redis repo now drives bundled modules from modules/modules.yaml and a manifest-based make workflow (modules-update / deploy), and can ship a prebuilt redis-full.tar.gz (core + modules) release asset.

- Pin module refs in modules/modules.yaml via yq (was: per-module Makefile MODULE_VERSION sed edits), from the REDIS*_VERSION build-args.
- Build via `make deploy`: module archs run `make modules-update MODULES_UPDATE_SHALLOW=1` + `make deploy`, or just `make deploy` when a bundled redis-full tree is detected (modules/*/src/.prepared); non-module archs run `make deploy redis`. Drop the now-redundant all/install/distclean.
- Workflow: prefer a redis-full.tar.gz release asset as REDIS_DOWNLOAD_URL for unstable/nightly/custom builds (falls back to the source archive). Release/PR keeps its URL+SHA in .redis.version.json.
- Add `redis_repo` input to workflows to use forks


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core image compile path and release archive selection; failures would break published images or module bundling, but scope is build/CI rather than runtime Redis behavior.
> 
> **Overview**
> Aligns **Docker image builds and CI** with Redis’s modernized module workflow (`modules/modules.yaml`, `make modules-update` / `make deploy`) and optional **`redis-full.tar.gz`** release bundles.
> 
> **CI/workflows** add a **`redis_repo`** input (default `redis/redis`) so sources and download URLs can come from a fork. For unstable/nightly/custom runs, archive resolution **tries `redis-full.tar.gz` first**, then falls back to tag/branch source tarballs; version extraction uses a stricter `src/version.h` path so module trees in a full bundle don’t confuse parsing. Image label generation **checks out the configured repo**, reads default module refs via **`manifest.sh`** instead of per-module `MODULE_VERSION` Makefiles, and sets **`io.redis.source`** from `redis_repo`.
> 
> **Alpine/Debian Dockerfiles** (and `.j2` templates) switch module builds from **`make all` / `install` / distclean** and RedisJSON-specific hacks to **`make deploy`** (or **`make deploy redis`** without modules). Custom builds **pin module refs with `yq` on `modules.yaml`** from `REDIS*_VERSION` build-args. When bundled sources are present (`modules/*/src/.prepared`), **`modules-update` is skipped**; otherwise shallow **`modules-update`** runs. Rust is **installed before `deploy` and uninstalled after** to keep images lean. **`yq`** is added as a build dependency on both distros.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0515b3b726a851b1ff73a089051737d59a1804f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->