### PR TITLE
Install yq only when build is custom

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -50,7 +50,6 @@ RUN set -eux; \
 		g++ \
 		git \
 		libffi-dev \
-		yq-go \
 		libgcc \
 		libtool \
 		llvm21-dev \

--- a/alpine/Dockerfile.j2
+++ b/alpine/Dockerfile.j2
@@ -47,6 +47,9 @@ RUN set -eux; \
 	esac; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 	apk add --no-cache --virtual .module-build-deps \
+		{% if custom_build %}
+		yq-go \
+		{% endif %}
 		autoconf \
 		automake \
 		bash \
@@ -61,7 +64,6 @@ RUN set -eux; \
 		g++ \
 		git \
 		libffi-dev \
-		yq-go \
 		libgcc \
 		libtool \
 		llvm21-dev \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -44,7 +44,6 @@ RUN set -eux; \
 		apt-get update; \
 		apt-get install -y --no-install-recommends \
 			git \
-			yq \
 			cmake \
 			python3 \
 			python3-pip \

--- a/debian/Dockerfile.j2
+++ b/debian/Dockerfile.j2
@@ -53,8 +53,10 @@ RUN set -eux; \
 		echo 'deb http://deb.debian.org/debian trixie-backports main' > /etc/apt/sources.list.d/backports.list; \
 		apt-get update; \
 		apt-get install -y --no-install-recommends \
-			git \
+			{% if custom_build %}
 			yq \
+			{% endif %}
+			git \
 			cmake \
 			python3 \
 			python3-pip \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build-dependency conditioning only; custom builds still get `yq`, and standard release builds never invoked the yaml-patching path.
> 
> **Overview**
> **`yq` is no longer installed for standard release/module Docker builds**—only when Dockerfiles are rendered with `custom_build` enabled.
> 
> In `alpine/Dockerfile.j2` and `debian/Dockerfile.j2`, `yq-go` / `yq` are wrapped in `{% if custom_build %}` inside the module build-deps block, matching the existing custom-build-only step that edits `modules.yaml` from `REDISEARCH_VERSION` and related build args. The checked-in `alpine/Dockerfile` and `debian/Dockerfile` are regenerated without those packages (default render uses `custom_build=false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbf2c21a0da11a43692a8ae8c40daa8d26a37b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->