### PR TITLE
release/8.10 Move modules-update to custom build and gate redis_repo

### DIFF
--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -79,6 +79,7 @@ jobs:
           INPUTS_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
           INPUTS_RELEASE_TYPE: ${{ github.event.inputs.release_type }}
           INPUTS_RUN_TYPE: ${{ github.event.inputs.run_type }}
+          INPUTS_REDIS_REPO: ${{ github.event.inputs.redis_repo }}
         shell: bash
         run: |
           if ! [[ "$INPUTS_RELEASE_TYPE" =~ ^(public|internal)$ ]]; then
@@ -93,6 +94,12 @@ jobs:
 
           if [ "$INPUTS_RUN_TYPE" != "release" ] && [ "$INPUTS_RELEASE_TYPE" = "public" ]; then
             echo "::error::Public release may have only run type 'release'"
+            exit 1
+          fi
+
+          # A fork may only be used for non-release runs; releases must build redis/redis
+          if [ "$INPUTS_RUN_TYPE" = "release" ] && [ "${INPUTS_REDIS_REPO:-redis/redis}" != "redis/redis" ]; then
+            echo "::error::Release builds must use redis_repo=redis/redis (got '$INPUTS_REDIS_REPO'); forks are allowed only for non-release runs"
             exit 1
           fi
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -110,12 +110,6 @@ RUN set -eux; \
 	export BUILD_TLS=yes; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 		export LTO=1; \
-# bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1; then \
-			echo "Using bundled module sources (redis-full); skipping modules-update"; \
-		else \
-			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
-		fi; \
 # make deploy/build.sh bypass modules/Makefile, so install the pinned Rust toolchain here
 		make -C /usr/src/redis/modules install-rust INSTALL_RUST_TOOLCHAIN=yes; \
 		make -C /usr/src/redis -j "$(nproc)" deploy; \

--- a/alpine/Dockerfile.j2
+++ b/alpine/Dockerfile.j2
@@ -138,13 +138,13 @@ RUN set -eux; \
 			[ -z "$REDISBLOOM_VERSION" ] || yq -i '(.modules[] | select(.name == "redisbloom").ref) = strenv(REDISBLOOM_VERSION)' /usr/src/redis/modules/modules.yaml; \
 			[ -z "$REDISTIMESERIES_VERSION" ] || yq -i '(.modules[] | select(.name == "redistimeseries").ref) = strenv(REDISTIMESERIES_VERSION)' /usr/src/redis/modules/modules.yaml; \
 		fi; \
-	{% endif %}
 # bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1{% if custom_build %} && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]{% endif %}; then \
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1 && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]; then \
 			echo "Using bundled module sources (redis-full); skipping modules-update"; \
 		else \
 			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
 		fi; \
+	{% endif %}
 # make deploy/build.sh bypass modules/Makefile, so install the pinned Rust toolchain here
 		make -C /usr/src/redis/modules install-rust INSTALL_RUST_TOOLCHAIN=yes; \
 		make -C /usr/src/redis -j "$(nproc)" deploy; \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -94,12 +94,6 @@ RUN set -eux; \
 	export BUILD_TLS=yes; \
 	if [ "$BUILD_WITH_MODULES" = "yes" ]; then \
 		export LTO=1; \
-# bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1; then \
-			echo "Using bundled module sources (redis-full); skipping modules-update"; \
-		else \
-			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
-		fi; \
 # make deploy/build.sh bypass modules/Makefile, so install the pinned Rust toolchain here
 		make -C /usr/src/redis/modules install-rust INSTALL_RUST_TOOLCHAIN=yes; \
 		make -C /usr/src/redis -j "$(nproc)" deploy; \

--- a/debian/Dockerfile.j2
+++ b/debian/Dockerfile.j2
@@ -121,13 +121,13 @@ RUN set -eux; \
 			[ -z "$REDISBLOOM_VERSION" ] || yq -y -i '(.modules[] | select(.name == "redisbloom").ref) = env.REDISBLOOM_VERSION' /usr/src/redis/modules/modules.yaml; \
 			[ -z "$REDISTIMESERIES_VERSION" ] || yq -y -i '(.modules[] | select(.name == "redistimeseries").ref) = env.REDISTIMESERIES_VERSION' /usr/src/redis/modules/modules.yaml; \
 		fi; \
-	{% endif %}
 # bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1{% if custom_build %} && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]{% endif %}; then \
+		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1 && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]; then \
 			echo "Using bundled module sources (redis-full); skipping modules-update"; \
 		else \
 			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
 		fi; \
+	{% endif %}
 # make deploy/build.sh bypass modules/Makefile, so install the pinned Rust toolchain here
 		make -C /usr/src/redis/modules install-rust INSTALL_RUST_TOOLCHAIN=yes; \
 		make -C /usr/src/redis -j "$(nproc)" deploy; \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect how release images fetch module sources and enforce release source repo policy; misconfiguration could break custom module builds or block legitimate release dispatches.
> 
> **Overview**
> **Release workflow** now rejects `run_type=release` when `redis_repo` is not `redis/redis`, so official release builds cannot pull Redis from a fork (forks remain allowed for custom/unstable/nightly runs).
> 
> **Standard release Docker images** (committed `alpine`/`debian` Dockerfiles) no longer run the bundled `modules-update` / `.prepared` skip logic during module builds—they go straight to Rust install and `make deploy`.
> 
> **Custom builds** (via `Dockerfile.j2` with `custom_build`) still pin module refs with `yq`, optionally skip `modules-update` when bundled `.prepared` sources exist and no module version overrides were passed, and otherwise run `modules-update`; that whole block is now wrapped entirely inside the `custom_build` template branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54eecdd64b6fb9a0f3d62349d43abdfc53cc3fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->