### PR TITLE
Unstable - Run modules-update on internal releases lacking redis-full

### DIFF
--- a/.github/actions/build-and-tag-locally/action.yml
+++ b/.github/actions/build-and-tag-locally/action.yml
@@ -42,6 +42,10 @@ inputs:
   run_type:
     description: 'Run type, either release, pr, nightly, unstable or custom'
     required: true
+  release_type:
+    description: 'Release type, either public or internal'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -192,6 +196,12 @@ runs:
         ./bin/render-all-dockerfiles.sh \
           -s custom_build true \
           -s redis_download_url $REDIS_DOWNLOAD_URL
+
+    - name: Render Dockerfiles for internal release
+      shell: bash
+      if: inputs.run_type == 'release' && inputs.release_type == 'internal'
+      run: |
+        ./bin/render-all-dockerfiles.sh -s internal true
 
     - name: Build
       id: build

--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -37,6 +37,11 @@ on:
         description: 'Run type, either release, pr, unstable, nightly or custom'
         required: false
         type: string
+      release_type:
+        description: 'Release type, either public or internal'
+        required: false
+        type: string
+        default: ''
       slack_channel_id:
         description: 'Slack channel ID to post notifications to'
         required: false
@@ -135,6 +140,7 @@ jobs:
           redisbloom_version: ${{ inputs.redisbloom_version }}
           redistimeseries_version: ${{ inputs.redistimeseries_version }}
           run_type: ${{ inputs.run_type }}
+          release_type: ${{ inputs.release_type }}
 
   create-multi-arch-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -182,6 +182,7 @@ jobs:
       redisbloom_version: ${{ github.event.inputs.redisbloom_version }}
       redistimeseries_version: ${{ github.event.inputs.redistimeseries_version }}
       run_type: ${{ github.event.inputs.run_type }}
+      release_type: ${{ github.event.inputs.release_type }}
       slack_channel_id: ${{ needs.prepare-release.outputs.slack_channel_id }}
       slack_thread_ts: ${{ needs.prepare-release.outputs.slack_thread_ts }}
       override_release_branch: ${{ github.event.inputs.override_release_branch }}

--- a/alpine/Dockerfile.j2
+++ b/alpine/Dockerfile.j2
@@ -138,10 +138,10 @@ RUN set -eux; \
 			[ -z "$REDISBLOOM_VERSION" ] || yq -i '(.modules[] | select(.name == "redisbloom").ref) = strenv(REDISBLOOM_VERSION)' /usr/src/redis/modules/modules.yaml; \
 			[ -z "$REDISTIMESERIES_VERSION" ] || yq -i '(.modules[] | select(.name == "redistimeseries").ref) = strenv(REDISTIMESERIES_VERSION)' /usr/src/redis/modules/modules.yaml; \
 		fi; \
-# bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1 && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]; then \
-			echo "Using bundled module sources (redis-full); skipping modules-update"; \
-		else \
+	{% endif %}
+	{% if custom_build or internal %}
+# clone module sources unless bundled redis-full (.prepared) sources are already present (custom builds also re-clone when refs are overridden)
+		if ! ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1{% if custom_build %} || [ -n "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]{% endif %}; then \
 			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
 		fi; \
 	{% endif %}

--- a/debian/Dockerfile.j2
+++ b/debian/Dockerfile.j2
@@ -121,10 +121,10 @@ RUN set -eux; \
 			[ -z "$REDISBLOOM_VERSION" ] || yq -y -i '(.modules[] | select(.name == "redisbloom").ref) = env.REDISBLOOM_VERSION' /usr/src/redis/modules/modules.yaml; \
 			[ -z "$REDISTIMESERIES_VERSION" ] || yq -y -i '(.modules[] | select(.name == "redistimeseries").ref) = env.REDISTIMESERIES_VERSION' /usr/src/redis/modules/modules.yaml; \
 		fi; \
-# bundled redis-full ships module sources (.prepared); re-clone only if refs were overridden
-		if ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1 && [ -z "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]; then \
-			echo "Using bundled module sources (redis-full); skipping modules-update"; \
-		else \
+	{% endif %}
+	{% if custom_build or internal %}
+# clone module sources unless bundled redis-full (.prepared) sources are already present (custom builds also re-clone when refs are overridden)
+		if ! ls /usr/src/redis/modules/*/src/.prepared >/dev/null 2>&1{% if custom_build %} || [ -n "${REDISEARCH_VERSION:-}${REDISJSON_VERSION:-}${REDISBLOOM_VERSION:-}${REDISTIMESERIES_VERSION:-}" ]{% endif %}; then \
 			make -C /usr/src/redis modules-update MODULES_UPDATE_SHALLOW=1; \
 		fi; \
 	{% endif %}

--- a/release-automation/src/stackbrew_generator/dockerfile.py
+++ b/release-automation/src/stackbrew_generator/dockerfile.py
@@ -12,11 +12,13 @@ class DockerfileContext(BaseModel):
 
     Attributes:
         custom_build: Whether this is a custom build
+        internal: Whether this is an internal release build
         redis_download_url: Redis source tarball download URL (required)
         redis_download_sha: Redis source tarball SHA256 checksum (required)
     """
     release_tag: str = ""
     custom_build: bool = False
+    internal: bool = False
     redis_download_url: str = ""
     redis_download_sha: str = ""
 


### PR DESCRIPTION
Internal-release tarballs may not bundle redis-full module sources, but the modules-update fallback was gated entirely behind custom_build, so internal releases (built with custom_build=false) never cloned them.

Add an `internal` template flag: keep yq version-pinning custom-only, but run the .prepared-gated modules-update for custom OR internal builds. Internal releases re-render with `-s internal true` at build time, so the committed official Dockerfile (custom_build=false, internal=false) stays clean and byte-identical to HEAD.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release Docker build logic for internal tarballs; mis-gating could skip or over-run `modules-update`, but scope is CI/templates only and public release artifacts stay unchanged in git.
> 
> **Overview**
> **Internal release builds** can ship Redis tarballs that omit bundled redis-full module sources, but the `modules-update` fallback lived only under `custom_build`, so those releases never cloned module sources and could fail module builds.
> 
> This PR adds an **`internal` Jinja flag** (wired through `DockerfileContext` and `release_type` on `build-n-test` / `build-and-tag-locally` / `release_build_and_test`). **yq module ref pinning stays custom-only**; **`make modules-update`** now runs for **custom or internal** builds when `.prepared` sources are missing (custom still re-clones when version overrides are set). For **`run_type=release` and `release_type=internal`**, CI re-renders Dockerfiles at build time with `./bin/render-all-dockerfiles.sh -s internal true`, so the committed official Dockerfiles remain `internal=false` and stay in sync with validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9967bb2f2a976a4deb8a4031cfc44d096e6658f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->