### PR TITLE
Update redis_version package

### DIFF
--- a/release-automation/uv.lock
+++ b/release-automation/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 [[package]]
 name = "redis-version"
 version = "0.1.0"
-source = { git = "https://github.com/redis/redis-oss-release-automation.git?subdirectory=packages%2Fredis-version#c2e8efe462775fcdaa22216fa829f84f9dd88d84" }
+source = { git = "https://github.com/redis/redis-oss-release-automation.git?subdirectory=packages%2Fredis-version#8291afe419998e3755caf429baaad9e14e78ef7c" }
 dependencies = [
     { name = "pydantic" },
     { name = "typer" },


### PR DESCRIPTION
Fixes version comparison

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump with no local code changes; risk is limited to behavior of the external version-comparison logic used during releases.
> 
> **Overview**
> Pins the **`redis-version`** git dependency in `release-automation/uv.lock` to commit `8291afe` (from `c2e8efe`), pulling in the upstream fix for **version comparison** described in the PR.
> 
> No other files change; release automation still resolves `redis-version` from `redis-oss-release-automation` (`packages/redis-version`) and uses it for parsing/filtering Redis versions in stackbrew workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b18572d8427a8aacbb5c301e8a01ab15ffa647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->