### PR TITLE
Remove unsupported architectures for bookworm

### DIFF
--- a/release-automation/src/stackbrew_generator/models.py
+++ b/release-automation/src/stackbrew_generator/models.py
@@ -33,13 +33,10 @@ DEBIAN_TRIXIE_ARCHITECTURES: Tuple[str, ...] = (
 )
 DEBIAN_BOOKWORM_ARCHITECTURES: Tuple[str, ...] = (
     "amd64",
-    "arm32v5",
     "arm32v7",
     "arm64v8",
     "i386",
-    "mips64le",
     "ppc64le",
-    "s390x",
 )
 ALPINE_ARCHITECTURES: Tuple[str, ...] = (
     "amd64",


### PR DESCRIPTION
Related to https://github.com/docker-library/official-images/pull/21977

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small metadata-only change to release automation; no runtime Redis or image build logic is modified in this diff.
> 
> **Overview**
> Updates **`DEBIAN_BOOKWORM_ARCHITECTURES`** in `models.py` so stackbrew metadata for Debian bookworm matches what Docker official images actually publish.
> 
> **Removed** from the bookworm tuple: `arm32v5`, `mips64le`, and `s390x`. Bookworm entries now list **amd64**, **arm32v7**, **arm64v8**, **i386**, and **ppc64le** only. Debian Trixie and Alpine architecture lists are unchanged.
> 
> This follows docker-library/official-images#21977 so generated stackbrew output does not claim platforms that are no longer built for bookworm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eee1c669067b5e80573d8913199fdb833b700ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->